### PR TITLE
feat: add house selection step at config time

### DIFF
--- a/custom_components/gazdebordeaux/config_flow.py
+++ b/custom_components/gazdebordeaux/config_flow.py
@@ -11,9 +11,10 @@ from homeassistant.config_entries import ConfigFlow, ConfigEntry, ConfigFlowResu
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
+from homeassistant.helpers.selector import selector
 
-from .const import DOMAIN
-from .gazdebordeaux import Gazdebordeaux
+from .const import DOMAIN, HOUSE
+from .gazdebordeaux import Gazdebordeaux, House
 from .option_flow import GazdebordeauxOptionFlow
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,27 +27,13 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 )
 
 
-async def _validate_login(
-    hass: HomeAssistant, login_data: dict[str, str]
-) -> dict[str, str]:
-    """Validate login data and return any errors."""
-    api = Gazdebordeaux(
-        async_create_clientsession(hass),
-        login_data[CONF_USERNAME],
-        login_data[CONF_PASSWORD],
-    )
-    errors: dict[str, str] = {}
-    try:
-        await api.async_login()
-    except Exception:
-        errors["base"] = "invalid_auth"
-    return errors
-
-
 class GazdebordeauxConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Gazdebordeaux."""
 
-    VERSION = 1
+    VERSION = 2
+    
+    data: dict[str, str | None] = {}
+    gdb: Gazdebordeaux | None = None
 
     def __init__(self) -> None:
         """Initialize a new GazdebordeauxConfigFlow."""
@@ -58,22 +45,72 @@ class GazdebordeauxConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle the initial step."""
         errors: dict[str, str] = {}
+                
         if user_input is not None:
+            self.gdb = Gazdebordeaux(
+                async_create_clientsession(self.hass),
+                user_input[CONF_USERNAME],
+                user_input[CONF_PASSWORD],
+            )
+            
+            errors: dict[str, str] = {}
+            try:
+                await self.gdb.async_login()
+            except Exception:
+                errors["base"] = "invalid_auth"
 
-            errors = await _validate_login(self.hass, user_input)
             if not errors:
-                return self._async_create_gazdebordeaux_entry(user_input)
+                self.data = user_input
+                self.data[HOUSE] = None
+                return await self.async_step_house()
 
         return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors, last_step=False
         )
 
+    async def async_step_house(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the house choice step."""
+
+        if self.gdb is None:
+            raise Exception("API not initialized")
+        
+        houses = await self.gdb.async_get_houses()
+        
+        if houses is None:
+            raise Exception("Could not get houses")
+
+        if len(houses) == 1:
+            return self._async_create_gazdebordeaux_entry(self.data, houses[0])
+
+        if user_input is not None:
+            self.data[HOUSE] = user_input[HOUSE]
+            house = next((house for house in houses if house.id == user_input[HOUSE]), None)
+            if house is None:
+                raise Exception("Could not get selected house")
+            return self._async_create_gazdebordeaux_entry(self.data, house)
+
+ 
+        schema = vol.Schema({
+            vol.Required(HOUSE): selector(
+                {
+                    "select": {
+                        "options": list(map(lambda house: {"label": f"{house.address} - {house.remoteAddressId} ({house.contractCategory})"  , "value": house.id}, houses))
+                    }
+                }
+            )
+        })
+
+        return self.async_show_form(
+            step_id="house", data_schema=schema, last_step=True
+        )
 
     @callback
-    def _async_create_gazdebordeaux_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
+    def _async_create_gazdebordeaux_entry(self, data: dict[str, Any], house: House) -> ConfigFlowResult:
         """Create the config entry."""
         return self.async_create_entry(
-            title=f"({data[CONF_USERNAME]})",
+            title=f"({data[CONF_USERNAME]}) - {house.address} - {house.remoteAddressId} ({house.contractCategory})",
             data=data,
         )
 

--- a/custom_components/gazdebordeaux/option_flow.py
+++ b/custom_components/gazdebordeaux/option_flow.py
@@ -19,23 +19,6 @@ from .gazdebordeaux import Gazdebordeaux
 
 _LOGGER = logging.getLogger(__name__)
 
-async def _validate_login(
-    hass: HomeAssistant, login_data: dict[str, str]
-) -> dict[str, str]:
-    """Validate login data and return any errors."""
-    api = Gazdebordeaux(
-        async_create_clientsession(hass),
-        login_data[CONF_USERNAME],
-        login_data[CONF_PASSWORD],
-    )
-    errors: dict[str, str] = {}
-    try:
-        await api.async_login()
-    except Exception:
-        errors["base"] = "invalid_auth"
-    return errors
-
-
 class GazdebordeauxOptionFlow(OptionsFlow):
     """Handle a config flow for Gazdebordeaux."""
 

--- a/custom_components/gazdebordeaux/strings.json
+++ b/custom_components/gazdebordeaux/strings.json
@@ -6,6 +6,11 @@
                     "username": "[%key:common::config_flow::data::username%]",
                     "password": "[%key:common::config_flow::data::password%]"
                 }
+            },
+            "house": {
+                "data": {
+                    "house": "Contrat"
+                }
             }
         }
     },
@@ -17,7 +22,8 @@
                 "data": {
                     "username": "[%key:common::config_flow::data::username%]",
                     "password": "[%key:common::config_flow::data::password%]",
-                    "reset_stats": "Efface tout l'historique de statistiques"
+                    "reset_stats": "Efface tout l'historique de statistiques",
+                    "house": "Id du contrat '/house/xxxxxxx'"
                 }
             }
         }


### PR DESCRIPTION
Suite à #10 

Un premier draft d'implé du selecteur de house (l'équivalent des contrats dans l'API) aux steps de config

Je PENSE que mes modifs du service Gazdebordeaux sont retrocompatibles, mais chaud d'avoir de l'input dessus

A terme (peut être dans une autre PR) j'aimerai créer et update une entity par contrat pour stocker les éventuelles horaires des heures pleines/heures creuses pour pouvoir trigger des automations en fonction de ça


