### PR TITLE
fix: migrate to new life.gazdebordeaux.fr/api endpoints (v1.1.6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dmypy.json
 .LSOverride
 .Spotlight-V100
 .Trashes
+
+.claude
+.devcontainer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.6] - 2026-04-24
+- Migrate to new `life.gazdebordeaux.fr/api` endpoints (old `lifeapi` subdomain now returns 403)
+- Send same-origin browser headers so login and data requests are accepted
+- Log the login response body on failure to aid debugging
+
 ## [1.1.2] - 2024-09-11
 - Fix Error adding entity
 

--- a/custom_components/gazdebordeaux/gazdebordeaux.py
+++ b/custom_components/gazdebordeaux/gazdebordeaux.py
@@ -6,11 +6,27 @@ from aiohttp import ClientSession
 from json.decoder import JSONDecodeError
 from typing import List, Any
 
-DATA_URL = "https://lifeapi.gazdebordeaux.fr{0}/consumptions"
-LOGIN_URL = "https://lifeapi.gazdebordeaux.fr/login_check"
-ME_URL = "https://lifeapi.gazdebordeaux.fr/users/me"
+DATA_URL = "https://life.gazdebordeaux.fr/api{0}/consumptions"
+LOGIN_URL = "https://life.gazdebordeaux.fr/api/login_check"
+ME_URL = "https://life.gazdebordeaux.fr/api/users/me"
 
 INPUT_DATE_FORMAT = "%Y-%m-%d"
+
+# Browser-like headers. The WAF on life.gazdebordeaux.fr rejects requests that
+# don't look like the SPA (same-origin fetch from the web app).
+BROWSER_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+    "Accept": "application/json",
+    "Accept-Language": "fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7",
+    "Origin": "https://life.gazdebordeaux.fr",
+    "Referer": "https://life.gazdebordeaux.fr/",
+    "Sec-Fetch-Dest": "empty",
+    "Sec-Fetch-Mode": "cors",
+    "Sec-Fetch-Site": "same-origin",
+    "Sec-Ch-Ua": '"Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"',
+    "Sec-Ch-Ua-Mobile": "?0",
+    "Sec-Ch-Ua-Platform": '"macOS"',
+}
 
 paris_tz = pytz.timezone('Europe/Paris')
 Logger = logging.getLogger(__name__)
@@ -41,14 +57,19 @@ class Gazdebordeaux:
 
     async def async_login(self):
         Logger.debug("Loging in...")
-        async with self._session.post(LOGIN_URL, json={
+        async with self._session.post(LOGIN_URL, headers=BROWSER_HEADERS, json={
             "email":self._username,
             "password":self._password
         }) as response:
-            token = await response.json()
+            body = await response.text()
+            Logger.debug("Login response status=%s content-type=%s body=%s", response.status, response.headers.get("Content-Type"), body)
+            try:
+                token = await response.json(content_type=None)
+            except JSONDecodeError:
+                raise Exception("Login response was not JSON (status=%s, content-type=%s): %s" % (response.status, response.headers.get("Content-Type"), body))
 
             if token["token"] is None:
-                raise Exception("invalid auth" + await response.text())
+                raise Exception("invalid auth" + body)
             Logger.debug("Login response OK")
             self._token = token["token"]
 
@@ -101,9 +122,10 @@ class Gazdebordeaux:
             Logger.debug("Loaded house info: %s", self._selectedHouse)
 
             headers = {
+                **BROWSER_HEADERS,
                 "Authorization": "Bearer " + self._token,
                 "Connection": "keep-alive",
-                "Content-Type": "application/json"
+                "Content-Type": "application/json",
             }
             payload = {
                 "email":self._username,
@@ -133,9 +155,10 @@ class Gazdebordeaux:
         Logger.debug("Loading house info...")
         
         headers = {
+            **BROWSER_HEADERS,
             "Authorization": "Bearer " + self._token,
             "Connection": "keep-alive",
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
         }
 
         # querying House id

--- a/custom_components/gazdebordeaux/manifest.json
+++ b/custom_components/gazdebordeaux/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/chriscamicas/gazdebordeaux-ha/issues",
   "requirements": [
   ],
-  "version": "1.1.5"
+  "version": "1.1.6"
 }


### PR DESCRIPTION
## Summary
- The old `lifeapi.gazdebordeaux.fr` subdomain now returns HTTP 403. Point `login`, `users/me`, and `consumptions` at `life.gazdebordeaux.fr/api/*` instead.
- Send same-origin browser headers (`Origin`, `Referer`, `Sec-Fetch-*`, `Sec-Ch-Ua*`, `User-Agent`) so requests are accepted.
- Log the login response body on JSON decode failure to make future regressions easier to diagnose.
- Bump version to `1.1.6` and add a changelog entry.
- Ignore local `.claude/` and `.devcontainer/` directories.