### PR TITLE
fix: remove duplicate /api prefix in DATA_URL

### DIFF
--- a/custom_components/gazdebordeaux/gazdebordeaux.py
+++ b/custom_components/gazdebordeaux/gazdebordeaux.py
@@ -6,7 +6,7 @@ from aiohttp import ClientSession
 from json.decoder import JSONDecodeError
 from typing import List, Any
 
-DATA_URL = "https://life.gazdebordeaux.fr/api{0}/consumptions"
+DATA_URL = "https://life.gazdebordeaux.fr{0}/consumptions"
 LOGIN_URL = "https://life.gazdebordeaux.fr/api/login_check"
 ME_URL = "https://life.gazdebordeaux.fr/api/users/me"
 


### PR DESCRIPTION
## Problem

After upgrading to v1.1.6, the consumption endpoint returns **404 Not Found**.

The `/users/me` endpoint returns `selectedHouse` as `/api/houses/{uuid}` (with the `/api` prefix). The `DATA_URL` in v1.1.6 was set to `https://life.gazdebordeaux.fr/api{0}/consumptions`, which results in a double `/api` path:

```
https://life.gazdebordeaux.fr/api/api/houses/{uuid}/consumptions  → 404
```

## Fix

Remove the `/api` prefix from `DATA_URL` since it's already included in the `selectedHouse` path returned by the API:

```python
# Before (broken)
DATA_URL = "https://life.gazdebordeaux.fr/api{0}/consumptions"

# After (fixed)
DATA_URL = "https://life.gazdebordeaux.fr{0}/consumptions"
```