### PR TITLE
fix: normalize /api prefix in house path (v1.1.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.8] - 2026-04-24
+- Normalize the house path so accounts whose `selectedHouse` is returned as `/houses/{uuid}` (without the `/api` prefix) no longer hit the SPA HTML fallback instead of the consumption JSON
+
 ## [1.1.7] - 2026-04-24
 - Log the consumption request URL, parameters, status, content-type, and body to help diagnose unexpected API responses
 - Raise clearer errors when the consumption payload is `None`, not a dict, or missing the `total` key, instead of a generic `KeyError`

--- a/custom_components/gazdebordeaux/gazdebordeaux.py
+++ b/custom_components/gazdebordeaux/gazdebordeaux.py
@@ -152,7 +152,15 @@ class Gazdebordeaux:
             if end is not None:
                 params["endDate"] = end.strftime("%Y-%m-%d")
 
-            url = DATA_URL.format(self._selectedHouse)
+            # selectedHouse can be "/houses/{uuid}" or "/api/houses/{uuid}" depending
+            # on the account; normalize to always include the /api prefix exactly once.
+            house = self._selectedHouse or ""
+            if not house.startswith("/api/"):
+                if not house.startswith("/"):
+                    house = "/" + house
+                house = "/api" + house
+
+            url = DATA_URL.format(house)
             Logger.debug("Fetching data url=%s params=%s", url, params)
             async with self._session.get(url, headers=headers, json=payload, params=params) as response:
                 body = await response.text()

--- a/custom_components/gazdebordeaux/manifest.json
+++ b/custom_components/gazdebordeaux/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/chriscamicas/gazdebordeaux-ha/issues",
   "requirements": [
   ],
-  "version": "1.1.7"
+  "version": "1.1.8"
 }


### PR DESCRIPTION
## Summary
- Fixes a regression where accounts whose `/users/me` returns `selectedHouse` as `/houses/{uuid}` (without the `/api` prefix) hit the SPA HTML fallback instead of the consumption JSON, which then broke with a `KeyError: 'total'`.
- PR #22 correctly fixed the opposite case (`/api/houses/{uuid}` producing a duplicated `/api`); both formats now coexist in the wild, so the house path is normalized at URL-construction time to always include the `/api` prefix exactly once.
- Bump version to `1.1.8` (rebased onto `main` which now has `1.1.7` from #23) and add a changelog entry.

## Evidence from a failing instance
```
url=https://life.gazdebordeaux.fr/houses/<uuid>/consumptions   (no /api)
Data response status=200 content-type=text/html body=<!DOCTYPE html>
```