### PR TITLE
fix: allow clearing the HOUSE option in the options flow (v1.1.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.9] - 2026-04-25
+- Allow clearing the optional HOUSE field in the options flow (was reverting to the previous value because the voluptuous default was re-injected on submit)
+
 ## [1.1.8] - 2026-04-24
 - Normalize the house path so accounts whose `selectedHouse` is returned as `/houses/{uuid}` (without the `/api` prefix) no longer hit the SPA HTML fallback instead of the consumption JSON
 

--- a/custom_components/gazdebordeaux/manifest.json
+++ b/custom_components/gazdebordeaux/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/chriscamicas/gazdebordeaux-ha/issues",
   "requirements": [
   ],
-  "version": "1.1.8"
+  "version": "1.1.9"
 }

--- a/custom_components/gazdebordeaux/option_flow.py
+++ b/custom_components/gazdebordeaux/option_flow.py
@@ -65,7 +65,7 @@ class GazdebordeauxOptionFlow(OptionsFlow):
                 ): bool,
                 vol.Optional(
                     HOUSE,
-                    default=self.config_entry.data.get(HOUSE, ""),
+                    description={"suggested_value": self.config_entry.data.get(HOUSE, "")},
                 ): str,
             }
         )


### PR DESCRIPTION
## Summary
- `vol.Optional(HOUSE, default=...)` re-injected the previous value when the field was submitted empty (voluptuous applies defaults to absent keys), so users could never clear the override.
- Switch the prefill to HA's `description={"suggested_value": ...}`, which controls display only and leaves the submitted empty value untouched.
- Bump version to `1.1.9` and add a changelog entry.