### PR TITLE
feat: auto-select gas house for multi-contract accounts (v1.1.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.9] - 2026-04-25
 - Allow clearing the optional HOUSE field in the options flow (was reverting to the previous value because the voluptuous default was re-injected on submit)
+- Pick the first gas-contract house automatically when the account has multiple contracts and no `selectedHouse` (e.g. gas + electricity customers)
 
 ## [1.1.8] - 2026-04-24
 - Normalize the house path so accounts whose `selectedHouse` is returned as `/houses/{uuid}` (without the `/api` prefix) no longer hit the SPA HTML fallback instead of the consumption JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.10] - 2026-04-25
+- Pick the first gas-contract house automatically when the account has multiple contracts and no `selectedHouse` (e.g. gas + electricity customers)
+
 ## [1.1.9] - 2026-04-25
 - Allow clearing the optional HOUSE field in the options flow (was reverting to the previous value because the voluptuous default was re-injected on submit)
-- Pick the first gas-contract house automatically when the account has multiple contracts and no `selectedHouse` (e.g. gas + electricity customers)
 
 ## [1.1.8] - 2026-04-24
 - Normalize the house path so accounts whose `selectedHouse` is returned as `/houses/{uuid}` (without the `/api` prefix) no longer hit the SPA HTML fallback instead of the consumption JSON

--- a/custom_components/gazdebordeaux/gazdebordeaux.py
+++ b/custom_components/gazdebordeaux/gazdebordeaux.py
@@ -179,23 +179,52 @@ class Gazdebordeaux:
             await self.async_login()
         if self._token is None:
             return
-        
+
         Logger.debug("Loading house info...")
-        
-        headers = {
+
+        # querying House id
+        async with self._session.get(ME_URL, headers=self._authenticated_headers()) as response:
+            try:
+                data = await response.json()
+                Logger.debug("Loaded house info: %s", data)
+            except JSONDecodeError:
+                Logger.error("An unexpected error occured while loading the house", exc_info=True)
+                raise
+
+        if data.get("selectedHouse"):
+            self._selectedHouse = data["selectedHouse"]
+            return
+
+        # Multi-contract accounts (e.g. gas + electricity) come back with no
+        # selectedHouse. Iterate the houses list and pick the first gas one.
+        houses = data.get("houses") or []
+        if not houses:
+            raise Exception("No houses found on this account")
+
+        Logger.debug("No selectedHouse; iterating over %d houses to find a gas contract", len(houses))
+        seen: list[tuple[str, str | None]] = []
+        for path in houses:
+            house = await self._fetch_house(path)
+            category = (house.get("contractType") or {}).get("category")
+            seen.append((path, category))
+            Logger.debug("House %s category=%s", path, category)
+            if category == "gas":
+                Logger.debug("Selected gas house %s", path)
+                self._selectedHouse = path
+                return
+
+        raise Exception("No gas contract found among %d houses: %s" % (len(houses), seen))
+
+    def _authenticated_headers(self) -> dict:
+        return {
             **BROWSER_HEADERS,
-            "Authorization": "Bearer " + self._token,
+            "Authorization": "Bearer " + (self._token or ""),
             "Connection": "keep-alive",
             "Content-Type": "application/json",
         }
 
-        # querying House id
-        async with self._session.get(ME_URL, headers=headers) as response:
-            try:
-                data = await response.json()
-                self._selectedHouse = data["selectedHouse"]
-                Logger.debug("Loaded house info: %s", data)
-
-            except JSONDecodeError:
-                Logger.error("An unexpected error occured while loading the house", exc_info=True)
-                raise
+    async def _fetch_house(self, path: str) -> Any:
+        url = "https://life.gazdebordeaux.fr" + path
+        Logger.debug("Fetching house %s", url)
+        async with self._session.get(url, headers=self._authenticated_headers()) as response:
+            return await response.json(content_type=None)

--- a/custom_components/gazdebordeaux/manifest.json
+++ b/custom_components/gazdebordeaux/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/chriscamicas/gazdebordeaux-ha/issues",
   "requirements": [
   ],
-  "version": "1.1.9"
+  "version": "1.1.10"
 }


### PR DESCRIPTION
## Summary
- Some Gaz de Bordeaux customers hold multiple contracts (e.g. gas + electricity). For those accounts `/users/me` returns `selectedHouse: null` and a `houses` array, so the previous code stored `None` and built a malformed URL.
- `loadHouse()` now early-returns when `selectedHouse` is set (single-house users — unchanged), otherwise iterates `data["houses"]`, fetches each via a small `_fetch_house()` helper, and picks the first whose `contractType.category == "gas"`.
- When no gas contract is found, raises a clear error including the list of `(path, category)` pairs to make diagnosis easy.
- Bump version to `1.1.10` and add a changelog entry.