### PR TITLE
WIP: feat: support multi-house (gaz + élec)

### DIFF
--- a/custom_components/gazdebordeaux/__init__.py
+++ b/custom_components/gazdebordeaux/__init__.py
@@ -13,19 +13,21 @@ PLATFORMS: list[Platform] = [Platform.SENSOR]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Gaz de Bordeaux from a config entry."""
-
-    coordinator = GdbCoordinator(hass, entry.data)
+    coordinator = GdbCoordinator(hass, entry.data, entry.options)
     await coordinator.async_config_entry_first_refresh()
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
-
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     return True
+
+
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload when options change."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
-
     return unload_ok

--- a/custom_components/gazdebordeaux/config_flow.py
+++ b/custom_components/gazdebordeaux/config_flow.py
@@ -1,7 +1,6 @@
 """Config flow for Gazdebordeaux integration."""
 from __future__ import annotations
 
-from collections.abc import Mapping
 import logging
 from typing import Any
 
@@ -10,9 +9,10 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigEntry, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
-from .const import DOMAIN
+from .const import DOMAIN, HOUSES
 from .gazdebordeaux import Gazdebordeaux
 from .option_flow import GazdebordeauxOptionFlow
 
@@ -26,59 +26,93 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 )
 
 
-async def _validate_login(
-    hass: HomeAssistant, login_data: dict[str, str]
-) -> dict[str, str]:
-    """Validate login data and return any errors."""
-    api = Gazdebordeaux(
-        async_create_clientsession(hass),
-        login_data[CONF_USERNAME],
-        login_data[CONF_PASSWORD],
-    )
-    errors: dict[str, str] = {}
-    try:
-        await api.async_login()
-    except Exception:
-        errors["base"] = "invalid_auth"
-    return errors
-
-
 class GazdebordeauxConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Gazdebordeaux."""
 
     VERSION = 1
 
     def __init__(self) -> None:
-        """Initialize a new GazdebordeauxConfigFlow."""
-        self.reauth_entry: ConfigEntry | None = None
-        self.utility_info: dict[str, Any] | None = None
+        self._user_data: dict[str, Any] = {}
+        self._discovered_houses: list[dict] = []
+        self._api: Gazdebordeaux | None = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle the initial step."""
+        """Step 1: login."""
         errors: dict[str, str] = {}
         if user_input is not None:
+            self._api = Gazdebordeaux(
+                async_create_clientsession(self.hass),
+                user_input[CONF_USERNAME],
+                user_input[CONF_PASSWORD],
+            )
+            try:
+                await self._api.async_login()
+            except Exception:
+                errors["base"] = "invalid_auth"
 
-            errors = await _validate_login(self.hass, user_input)
             if not errors:
-                return self._async_create_gazdebordeaux_entry(user_input)
+                self._user_data = user_input
+                return await self.async_step_houses()
 
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
         )
 
+    async def async_step_houses(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Step 2: select houses."""
+        if user_input is not None:
+            selected = user_input.get("selected_houses", [])
+            houses_config = [
+                h for h in self._discovered_houses if h["path"] in selected
+            ]
+            return self.async_create_entry(
+                title=f"({self._user_data[CONF_USERNAME]})",
+                data=self._user_data,
+                options={HOUSES: houses_config},
+            )
 
-    @callback
-    def _async_create_gazdebordeaux_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
-        """Create the config entry."""
-        return self.async_create_entry(
-            title=f"({data[CONF_USERNAME]})",
-            data=data,
+        # Discover houses
+        try:
+            house_paths = await self._api.async_load_houses()
+        except Exception:
+            _LOGGER.error("Failed to load houses", exc_info=True)
+            return self.async_create_entry(
+                title=f"({self._user_data[CONF_USERNAME]})",
+                data=self._user_data,
+            )
+
+        self._discovered_houses = []
+        options = {}
+        for path in house_paths:
+            try:
+                house_type = await self._api.async_detect_house_type(path)
+            except Exception:
+                house_type = "unknown"
+            label = {"gas": "Gaz", "elec": "Électricité"}.get(house_type, house_type)
+            self._discovered_houses.append({"path": path, "type": house_type})
+            options[path] = label
+
+        if not options:
+            return self.async_create_entry(
+                title=f"({self._user_data[CONF_USERNAME]})",
+                data=self._user_data,
+            )
+
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    "selected_houses", default=list(options.keys())
+                ): cv.multi_select(options),
+            }
         )
+
+        return self.async_show_form(step_id="houses", data_schema=schema)
 
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: ConfigEntry):
-        """Get options flow for this handler"""
         return GazdebordeauxOptionFlow(config_entry)

--- a/custom_components/gazdebordeaux/const.py
+++ b/custom_components/gazdebordeaux/const.py
@@ -3,3 +3,4 @@
 DOMAIN = "gazdebordeaux"
 RESET_STATISTICS = "reset_stats"
 HOUSE = "house"
+HOUSES = "houses"

--- a/custom_components/gazdebordeaux/coordinator.py
+++ b/custom_components/gazdebordeaux/coordinator.py
@@ -1,11 +1,11 @@
-"""Coordinator to handle Opower connections."""
+"""Coordinator to handle Gaz de Bordeaux connections."""
 from datetime import datetime, timedelta
 import logging
 from types import MappingProxyType
 from typing import Any, cast
 
-from .const import RESET_STATISTICS, HOUSE
-from .gazdebordeaux import Gazdebordeaux, DailyUsageRead, TotalUsageRead
+from .const import RESET_STATISTICS, HOUSE, HOUSES
+from .gazdebordeaux import Gazdebordeaux, DailyUsageRead, TotalUsageRead, HouseData
 
 from homeassistant.components.recorder.models import (
     StatisticData,
@@ -22,8 +22,7 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntries, ConfigEntry
-# from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, UnitOfEnergy, UnitOfVolume, UnitOfCurrency
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_PASSWORD,
     CONF_USERNAME,
@@ -41,25 +40,22 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
-class GdbCoordinator(DataUpdateCoordinator[TotalUsageRead]):
-    """Handle fetching GazdeBordeaux data, updating sensors and inserting statistics."""
+class GdbCoordinator(DataUpdateCoordinator[dict[str, HouseData]]):
+    """Handle fetching GazdeBordeaux data for multiple houses."""
 
     def __init__(
         self,
         hass: HomeAssistant,
         entry_data: MappingProxyType[str, Any],
+        entry_options: MappingProxyType[str, Any] | None = None,
     ) -> None:
-        """Initialize the data handler."""
         super().__init__(
             hass,
             _LOGGER,
             name="gazdebordeaux",
-            # Data is updated daily.
-            # Refresh every 12h to be at most 12h behind.
             update_interval=timedelta(hours=12),
         )
 
-        # Initialisation de la date de dernière actualisation
         self.last_update: datetime | None = None
 
         house: Any = None
@@ -73,17 +69,19 @@ class GdbCoordinator(DataUpdateCoordinator[TotalUsageRead]):
             None,
             house
         )
+
+        # Houses to query (from options, or fallback to selectedHouse)
+        self._configured_houses: list[dict] = []
+        if entry_options and HOUSES in entry_options:
+            self._configured_houses = entry_options[HOUSES]
+
         self.reset = False
         if RESET_STATISTICS in entry_data:
             self.reset = bool(entry_data[RESET_STATISTICS])
             if self.reset:
                 _LOGGER.debug("Asked to reset all statistics...")
-                entries=self.hass.config_entries.async_entries(DOMAIN)
-
-                house: Any = None
-                if HOUSE in entry_data:
-                    house = entry_data[HOUSE]
-
+                entries = self.hass.config_entries.async_entries(DOMAIN)
+                house = entry_data.get(HOUSE)
                 _LOGGER.debug("Updating config...")
                 self.hass.config_entries.async_update_entry(
                     entries[0], data={
@@ -97,48 +95,47 @@ class GdbCoordinator(DataUpdateCoordinator[TotalUsageRead]):
         @callback
         def _dummy_listener() -> None:
             pass
-
-        # Force the coordinator to periodically update by registering at least one listener.
-        # Needed when the _async_update_data below returns {} for utilities that don't provide
-        # forecast, which results to no sensors added, no registered listeners, and thus
-        # _async_update_data not periodically getting called which is needed for _insert_statistics.
         self.async_add_listener(_dummy_listener)
 
-    async def _async_update_data(
-        self,
-    ) -> TotalUsageRead:
-        """Fetch data from API endpoint."""
+    async def _async_update_data(self) -> dict[str, HouseData]:
+        """Fetch data from all configured houses."""
         try:
-            # Login expires after a few minutes.
-            # Given the infrequent updating (every 12h)
-            # assume previous session has expired and re-login.
             await self.api.async_login()
         except Exception as err:
             raise ConfigEntryAuthFailed from err
 
-        totalUsage: TotalUsageRead = await self.api.async_get_total_usage()
+        houses_data: dict[str, HouseData] = {}
 
-        # Because Opower provides historical usage/cost with a delay of a couple of days
-        # we need to insert data into statistics.
-        await self._insert_statistics()
+        if self._configured_houses:
+            # Multi-house mode: query each configured house
+            for h in self._configured_houses:
+                try:
+                    data = await self.api.async_get_house_data(h["path"])
+                    houses_data[data.house_type] = data
+                except Exception:
+                    _LOGGER.error("Error fetching house %s", h["path"], exc_info=True)
+        else:
+            # Legacy mode: query only selectedHouse (backward compat)
+            try:
+                data = await self.api.async_get_house_data(
+                    self.api._selectedHouse or (await self.api.async_load_houses())[0]
+                )
+                houses_data[data.house_type] = data
+            except Exception:
+                _LOGGER.error("Error fetching default house", exc_info=True)
 
-        # Mise à jour de la date de dernière actualisation
+        # Statistics import (gas only, backward compat)
+        if "gas" in houses_data:
+            await self._insert_statistics()
+
         self.last_update = datetime.now()
-        _LOGGER.debug("Last update: %s", self.last_update.strftime("%Y-%m-%d %H:%M:%S"))
-
-        return totalUsage
+        return houses_data
 
     async def _insert_statistics(self) -> None:
         """Insert gdb statistics."""
         cost_statistic_id = f"{DOMAIN}:energy_cost"
         consumption_statistic_id = f"{DOMAIN}:energy_consumption"
         volume_statistic_id = f"{DOMAIN}:volume"
-        _LOGGER.debug(
-            "Updating Statistics for %s, %s and %s",
-            cost_statistic_id,
-            consumption_statistic_id,
-            volume_statistic_id
-        )
 
         if self.reset:
             _LOGGER.debug("Resetting all statistics...")
@@ -154,16 +151,14 @@ class GdbCoordinator(DataUpdateCoordinator[TotalUsageRead]):
             volume_sum = 0.0
             last_stat_ts = None
         else:
-            last_stat_ts = last_stat[consumption_statistic_id][0]["start"] # type: ignore
+            last_stat_ts = last_stat[consumption_statistic_id][0]["start"]
             last_stat_date = datetime.fromtimestamp(last_stat_ts)
             _LOGGER.debug("Last stat found for %s...", last_stat_date.strftime("%Y-%m-%d"))
-            usage_reads = await self._async_get_recent_usage_reads(
-                last_stat_ts
-            )
+            usage_reads = await self._async_get_recent_usage_reads(last_stat_ts)
             if not usage_reads:
                 _LOGGER.debug("No recent usage/cost data. Skipping update")
                 return
-            
+
             stats = await get_instance(self.hass).async_add_executor_job(
                 statistics_during_period,
                 self.hass,
@@ -174,12 +169,9 @@ class GdbCoordinator(DataUpdateCoordinator[TotalUsageRead]):
                 None,
                 {"state", "sum"},
             )
-            # s:StatisticsRow =stats[cost_statistic_id][0]
-            
-            cost_sum = cast(float, stats[cost_statistic_id][0]["sum"]) # type: ignore
-            consumption_sum = cast(float, stats[consumption_statistic_id][0]["sum"])  # type: ignore
-            volume_sum = cast(float, stats[volume_statistic_id][0]["sum"])  # type: ignore
-            # last_stat_ts = stats[cost_statistic_id][0]["start"]  # type: ignore
+            cost_sum = cast(float, stats[cost_statistic_id][0]["sum"])
+            consumption_sum = cast(float, stats[consumption_statistic_id][0]["sum"])
+            volume_sum = cast(float, stats[volume_statistic_id][0]["sum"])
 
         cost_statistics = []
         consumption_statistics = []
@@ -187,79 +179,38 @@ class GdbCoordinator(DataUpdateCoordinator[TotalUsageRead]):
 
         for usage_read in usage_reads:
             start = usage_read.date
-            start.tzinfo
             if last_stat_ts is not None:
                 if start.timestamp() <= last_stat_ts:
-                    _LOGGER.debug("Skipping data for %s (timestamp)", start.strftime("%Y-%m-%d"))
                     continue
-                # if we are on the same day, skip it as well regarding of the time (to prevent multiple run for the same day)
                 if start.date() == last_stat_date.date():
-                    _LOGGER.debug("Skipping data for %s (same date)", start.strftime("%Y-%m-%d"))
                     continue
-            
-            _LOGGER.debug("Importing data for %s...", start.strftime("%Y-%m-%d"))
 
             cost_sum += usage_read.price
             consumption_sum += usage_read.amountOfEnergy
             volume_sum += usage_read.volumeOfEnergy
 
-            cost_statistics.append(
-                StatisticData(
-                    start=start, state=usage_read.price, sum=cost_sum
-                )
-            )
-            consumption_statistics.append(
-                StatisticData(
-                    start=start, state=usage_read.amountOfEnergy, sum=consumption_sum
-                )
-            )
-            volume_statistics.append(
-                StatisticData(
-                    start=start, state=usage_read.volumeOfEnergy, sum=volume_sum
-                )
-            )
+            cost_statistics.append(StatisticData(start=start, state=usage_read.price, sum=cost_sum))
+            consumption_statistics.append(StatisticData(start=start, state=usage_read.amountOfEnergy, sum=consumption_sum))
+            volume_statistics.append(StatisticData(start=start, state=usage_read.volumeOfEnergy, sum=volume_sum))
 
-        name_prefix = " ".join(
-            (
-                "Gaz de Bordeaux",
-            )
-        )
-        
+        name_prefix = "Gaz de Bordeaux"
+
         cost_metadata = StatisticMetaData(
-            has_mean=False,
-            mean_type=StatisticMeanType.NONE,
-            # unit_class="monetary",
-            unit_class=None,
-            has_sum=True,
-            name=f"{name_prefix} cost",
-            source=DOMAIN,
-            statistic_id=cost_statistic_id,
-            unit_of_measurement=CURRENCY_EURO,
-            device_class=SensorDeviceClass.MONETARY,
+            has_mean=False, mean_type=StatisticMeanType.NONE, unit_class=None, has_sum=True,
+            name=f"{name_prefix} cost", source=DOMAIN, statistic_id=cost_statistic_id,
+            unit_of_measurement=CURRENCY_EURO, device_class=SensorDeviceClass.MONETARY,
             state_class=SensorStateClass.TOTAL
         )
         consumption_metadata = StatisticMetaData(
-            has_mean=False,
-            mean_type=StatisticMeanType.NONE,
-            unit_class="energy",
-            has_sum=True,
-            name=f"{name_prefix} consumption",
-            source=DOMAIN,
-            statistic_id=consumption_statistic_id,
-            unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-            device_class=SensorDeviceClass.ENERGY,
+            has_mean=False, mean_type=StatisticMeanType.NONE, unit_class="energy", has_sum=True,
+            name=f"{name_prefix} consumption", source=DOMAIN, statistic_id=consumption_statistic_id,
+            unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR, device_class=SensorDeviceClass.ENERGY,
             state_class=SensorStateClass.TOTAL
         )
         volume_metadata = StatisticMetaData(
-            has_mean=False,
-            mean_type=StatisticMeanType.NONE,
-            unit_class="volume",
-            has_sum=True,
-            name=f"{name_prefix} volume",
-            source=DOMAIN,
-            statistic_id=volume_statistic_id,
-            unit_of_measurement=UnitOfVolume.CUBIC_METERS,
-            device_class=SensorDeviceClass.GAS,
+            has_mean=False, mean_type=StatisticMeanType.NONE, unit_class="volume", has_sum=True,
+            name=f"{name_prefix} volume", source=DOMAIN, statistic_id=volume_statistic_id,
+            unit_of_measurement=UnitOfVolume.CUBIC_METERS, device_class=SensorDeviceClass.GAS,
             state_class=SensorStateClass.TOTAL
         )
 
@@ -268,24 +219,12 @@ class GdbCoordinator(DataUpdateCoordinator[TotalUsageRead]):
         async_add_external_statistics(self.hass, volume_metadata, volume_statistics)
 
     async def _async_get_all_data(self) -> list[DailyUsageRead]:
-        """Get all cost reads since account activation but at different resolutions depending on age.
-
-        - month resolution for all years (since account activation)
-        - day resolution for past 3 years (if account's read resolution supports it)
-        - hour resolution for past 2 months (if account's read resolution supports it)
-        """
-        usage_reads = []
-
-        # if start=None it will only default to beginning of current year, let's import 1 year more
-        start = datetime(datetime.today().year-1, 1, 1)
+        start = datetime(datetime.today().year - 1, 1, 1)
         end = datetime.now()
-        usage_reads = await self.api.async_get_daily_usage(start, end)
-        return usage_reads
+        return await self.api.async_get_daily_usage(start, end)
 
     async def _async_get_recent_usage_reads(self, last_stat_time: float) -> list[DailyUsageRead]:
-        """Get cost reads within the past 30 days to allow corrections in data from utilities."""
         return await self.api.async_get_daily_usage(
-            # datetime.fromtimestamp(last_stat_time) - timedelta(days=30),
             datetime.fromtimestamp(last_stat_time),
             datetime.now(),
         )

--- a/custom_components/gazdebordeaux/gazdebordeaux.py
+++ b/custom_components/gazdebordeaux/gazdebordeaux.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import pytz
 from aiohttp import ClientSession
 from json.decoder import JSONDecodeError
-from typing import List, Any
+from typing import List, Any, Optional
 
 DATA_URL = "https://life.gazdebordeaux.fr{0}/consumptions"
 LOGIN_URL = "https://life.gazdebordeaux.fr/api/login_check"
@@ -12,8 +12,6 @@ ME_URL = "https://life.gazdebordeaux.fr/api/users/me"
 
 INPUT_DATE_FORMAT = "%Y-%m-%d"
 
-# Browser-like headers. The WAF on life.gazdebordeaux.fr rejects requests that
-# don't look like the SPA (same-origin fetch from the web app).
 BROWSER_HEADERS = {
     "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
     "Accept": "application/json",
@@ -31,12 +29,31 @@ BROWSER_HEADERS = {
 paris_tz = pytz.timezone('Europe/Paris')
 Logger = logging.getLogger(__name__)
 
-# ------------------------------------------------------------------------------------------------------------
+
 @dataclasses.dataclass
 class TotalUsageRead:
     amountOfEnergy: float
     volumeOfEnergy: float
     price: float
+
+
+@dataclasses.dataclass
+class MonthlyRead:
+    kwh: float
+    price: float
+    volumeOfEnergy: float
+    contractPrice: float
+    consumptionPrice: float
+
+
+@dataclasses.dataclass
+class HouseData:
+    """All data for one house."""
+    house_type: str  # "gas" or "elec"
+    total: TotalUsageRead
+    current_month: Optional[MonthlyRead]
+    previous_month: Optional[MonthlyRead]
+
 
 @dataclasses.dataclass
 class DailyUsageRead:
@@ -46,185 +63,157 @@ class DailyUsageRead:
     price: float
     ratio: float
     temperature: float
-# ------------------------------------------------------------------------------------------------------------
+
+
 class Gazdebordeaux:
     def __init__(self, session: ClientSession, username: str, password: str, token=None, house=None):
         self._session = session
         self._username = username
         self._password = password
-        self._token: str|None = token
-        self._selectedHouse: str|None = house
+        self._token: str | None = token
+        self._selectedHouse: str | None = house or None
+        self._all_houses: List[str] = []
 
     async def async_login(self):
-        Logger.debug("Loging in...")
+        Logger.debug("Logging in...")
         async with self._session.post(LOGIN_URL, headers=BROWSER_HEADERS, json={
-            "email":self._username,
-            "password":self._password
+            "email": self._username,
+            "password": self._password
         }) as response:
             body = await response.text()
-            Logger.debug("Login response status=%s content-type=%s body=%s", response.status, response.headers.get("Content-Type"), body)
+            Logger.debug("Login response status=%s", response.status)
             try:
                 token = await response.json(content_type=None)
             except JSONDecodeError:
-                raise Exception("Login response was not JSON (status=%s, content-type=%s): %s" % (response.status, response.headers.get("Content-Type"), body))
-
-            if token["token"] is None:
-                raise Exception("invalid auth" + body)
-            Logger.debug("Login response OK")
+                raise Exception(
+                    "Login response was not JSON (status=%s): %s"
+                    % (response.status, body)
+                )
+            if token.get("token") is None:
+                raise Exception("invalid auth: " + body)
             self._token = token["token"]
 
-    # ------------------------------------------------------
-    async def async_get_total_usage(self):
-        monthly_data = await self.async_get_data(None, None, "year")
-        Logger.debug("Total usage raw response: %s", monthly_data)
-
-        if monthly_data is None:
-            raise Exception("Total usage response was None (likely login/auth failure)")
-        if not isinstance(monthly_data, dict):
-            raise Exception("Unexpected total usage response type=%s value=%r" % (type(monthly_data).__name__, monthly_data))
-        if "total" not in monthly_data:
-            Logger.error("Total usage response missing 'total' key. Keys: %s. Full response: %s", list(monthly_data.keys()), monthly_data)
-            raise Exception("Total usage response missing 'total' key. Keys present: %s" % list(monthly_data.keys()))
-
-        d = monthly_data["total"]
-        return TotalUsageRead(
-                amountOfEnergy = d["kwh"],
-                volumeOfEnergy = d["volumeOfEnergy"],
-                price = d["price"],
-            )
-
-    async def async_get_daily_usage(self, start: datetime|None, end: datetime|None) -> List[DailyUsageRead]:
-        daily_data = await self.async_get_data(start, end, "month")
-        Logger.debug("Daily usage raw response: %s", daily_data)
-
-        if daily_data is None:
-            raise Exception("Daily usage response was None (likely login/auth failure)")
-        if not isinstance(daily_data, dict):
-            raise Exception("Unexpected daily usage response type=%s value=%r" % (type(daily_data).__name__, daily_data))
-
-        usageReads: List[DailyUsageRead] = []
-
-        for d in daily_data:
-            if d == "total":
-                continue
-            usageReads.append(DailyUsageRead(
-                date = datetime.strptime(d, INPUT_DATE_FORMAT).replace(tzinfo=paris_tz),
-                amountOfEnergy = daily_data[d]["kwh"],
-                volumeOfEnergy = daily_data[d]["volumeOfEnergy"],
-                price = daily_data[d]["price"],
-                ratio = daily_data[d]["ratio"],
-                temperature = daily_data[d]["temperature"],
-
-            ))
-        
-        # Logger.debug("Data transformed: %s", usageReads)
-        return usageReads
-
-
-    async def async_get_data(self, start: datetime|None, end: datetime|None, scale: str) -> Any:
-        try:
-            if self._token is None:
-                await self.async_login()
-            if self._token is None:
-                return None
-
-            if self._selectedHouse is None:
-                await self.loadHouse()
-                Logger.debug("Loading last selected house")
-
-            Logger.debug("Loaded house info: %s", self._selectedHouse)
-
-            headers = {
-                **BROWSER_HEADERS,
-                "Authorization": "Bearer " + self._token,
-                "Connection": "keep-alive",
-                "Content-Type": "application/json",
-            }
-            payload = {
-                "email":self._username,
-                "password":self._password
-            }
-            params = {
-                "scale": scale
-            }
-            if start is not None:
-                params["startDate"] = start.strftime("%Y-%m-%d")
-            if end is not None:
-                params["endDate"] = end.strftime("%Y-%m-%d")
-
-            # selectedHouse can be "/houses/{uuid}" or "/api/houses/{uuid}" depending
-            # on the account; normalize to always include the /api prefix exactly once.
-            house = self._selectedHouse or ""
-            if not house.startswith("/api/"):
-                if not house.startswith("/"):
-                    house = "/" + house
-                house = "/api" + house
-
-            url = DATA_URL.format(house)
-            Logger.debug("Fetching data url=%s params=%s", url, params)
-            async with self._session.get(url, headers=headers, json=payload, params=params) as response:
-                body = await response.text()
-                Logger.debug("Data response status=%s content-type=%s body=%s", response.status, response.headers.get("Content-Type"), body)
-                try:
-                    return await response.json(content_type=None)
-                except JSONDecodeError:
-                    raise Exception("Data response was not JSON (status=%s, content-type=%s): %s" % (response.status, response.headers.get("Content-Type"), body))
-
-        except Exception:
-            Logger.error("An unexpected error occured while loading the data", exc_info=True)
-            raise
-
-    async def loadHouse(self):
+    async def async_load_houses(self) -> List[str]:
+        """Load all houses from the user profile."""
         if self._token is None:
             await self.async_login()
-        if self._token is None:
-            return
-
-        Logger.debug("Loading house info...")
-
-        # querying House id
-        async with self._session.get(ME_URL, headers=self._authenticated_headers()) as response:
-            try:
-                data = await response.json()
-                Logger.debug("Loaded house info: %s", data)
-            except JSONDecodeError:
-                Logger.error("An unexpected error occured while loading the house", exc_info=True)
-                raise
-
-        if data.get("selectedHouse"):
+        headers = {**BROWSER_HEADERS, "Authorization": "Bearer " + self._token}
+        async with self._session.get(ME_URL, headers=headers) as response:
+            data = await response.json()
             self._selectedHouse = data["selectedHouse"]
-            return
+            self._all_houses = data.get("houses", [self._selectedHouse])
+            Logger.debug("Houses: %s", self._all_houses)
+            return self._all_houses
 
-        # Multi-contract accounts (e.g. gas + electricity) come back with no
-        # selectedHouse. Iterate the houses list and pick the first gas one.
-        houses = data.get("houses") or []
-        if not houses:
-            raise Exception("No houses found on this account")
+    async def async_detect_house_type(self, house_path: str) -> str:
+        """Detect if a house is gas or elec by checking volumeOfEnergy."""
+        yearly = await self._get_house_data(house_path, None, None, "year")
+        total = yearly.get("total", {})
+        return "gas" if total.get("volumeOfEnergy", 0) > 0 else "elec"
 
-        Logger.debug("No selectedHouse; iterating over %d houses to find a gas contract", len(houses))
-        seen: list[tuple[str, str | None]] = []
-        for path in houses:
-            house = await self._fetch_house(path)
-            category = (house.get("contractType") or {}).get("category")
-            seen.append((path, category))
-            Logger.debug("House %s category=%s", path, category)
-            if category == "gas":
-                Logger.debug("Selected gas house %s", path)
-                self._selectedHouse = path
-                return
+    async def async_get_house_data(self, house_path: str) -> HouseData:
+        """Fetch yearly data for a house and return structured data."""
+        yearly = await self._get_house_data(house_path, None, None, "year")
+        total_raw = yearly["total"]
 
-        raise Exception("No gas contract found among %d houses: %s" % (len(houses), seen))
+        total = TotalUsageRead(
+            amountOfEnergy=total_raw.get("kwh", 0),
+            volumeOfEnergy=total_raw.get("volumeOfEnergy", 0),
+            price=total_raw.get("price", 0),
+        )
+        house_type = "gas" if total.volumeOfEnergy > 0 else "elec"
+        current, previous = self._extract_monthly(yearly)
 
-    def _authenticated_headers(self) -> dict:
-        return {
+        return HouseData(
+            house_type=house_type,
+            total=total,
+            current_month=current,
+            previous_month=previous,
+        )
+
+    def _extract_monthly(self, yearly_data: dict):
+        """Extract current and previous month from yearly API response."""
+        now = datetime.now(paris_tz)
+        current_key = now.strftime("%Y-%m")
+        prev_month = now.month - 1 or 12
+        prev_year = now.year if now.month > 1 else now.year - 1
+        prev_key = f"{prev_year}-{prev_month:02d}"
+
+        current = None
+        previous = None
+
+        for key, val in yearly_data.items():
+            if key == "total" or not isinstance(val, dict):
+                continue
+            if key == current_key:
+                current = self._parse_monthly(val)
+            elif key == prev_key:
+                previous = self._parse_monthly(val)
+
+        return current, previous
+
+    @staticmethod
+    def _parse_monthly(data: dict) -> MonthlyRead:
+        return MonthlyRead(
+            kwh=data.get("kwh", 0),
+            price=data.get("price", 0),
+            volumeOfEnergy=data.get("volumeOfEnergy", 0),
+            contractPrice=data.get("contractPrice", 0),
+            consumptionPrice=data.get("consumptionPrice", 0),
+        )
+
+    # --- backward compat: used by coordinator for statistics import ---
+
+    async def async_get_total_usage(self) -> TotalUsageRead:
+        yearly = await self.async_get_data(None, None, "year")
+        d = yearly["total"]
+        return TotalUsageRead(
+            amountOfEnergy=d["kwh"],
+            volumeOfEnergy=d["volumeOfEnergy"],
+            price=d["price"],
+        )
+
+    async def async_get_daily_usage(self, start, end) -> List[DailyUsageRead]:
+        daily_data = await self.async_get_data(start, end, "month")
+        reads = []
+        for key, val in daily_data.items():
+            if key == "total":
+                continue
+            reads.append(DailyUsageRead(
+                date=datetime.strptime(key, INPUT_DATE_FORMAT).replace(tzinfo=paris_tz),
+                amountOfEnergy=val["kwh"],
+                volumeOfEnergy=val["volumeOfEnergy"],
+                price=val["price"],
+                ratio=val["ratio"],
+                temperature=val["temperature"],
+            ))
+        return reads
+
+    async def async_get_data(self, start, end, scale) -> Any:
+        if self._selectedHouse is None:
+            await self.async_load_houses()
+        return await self._get_house_data(self._selectedHouse, start, end, scale)
+
+    async def _get_house_data(self, house_path, start, end, scale) -> Any:
+        if self._token is None:
+            await self.async_login()
+
+        headers = {
             **BROWSER_HEADERS,
-            "Authorization": "Bearer " + (self._token or ""),
-            "Connection": "keep-alive",
+            "Authorization": "Bearer " + self._token,
             "Content-Type": "application/json",
         }
+        params = {"scale": scale}
+        if start is not None:
+            params["startDate"] = start.strftime("%Y-%m-%d")
+        if end is not None:
+            params["endDate"] = end.strftime("%Y-%m-%d")
 
-    async def _fetch_house(self, path: str) -> Any:
-        url = "https://life.gazdebordeaux.fr" + path
-        Logger.debug("Fetching house %s", url)
-        async with self._session.get(url, headers=self._authenticated_headers()) as response:
-            return await response.json(content_type=None)
+        async with self._session.get(
+            DATA_URL.format(house_path), headers=headers, params=params
+        ) as response:
+            return await response.json()
+
+    async def loadHouse(self):
+        """Legacy compat."""
+        await self.async_load_houses()

--- a/custom_components/gazdebordeaux/option_flow.py
+++ b/custom_components/gazdebordeaux/option_flow.py
@@ -11,26 +11,11 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
-from .const import DOMAIN, RESET_STATISTICS, HOUSE
+from homeassistant.helpers import config_validation as cv
+from .const import DOMAIN, RESET_STATISTICS, HOUSE, HOUSES
 from .gazdebordeaux import Gazdebordeaux
 
 _LOGGER = logging.getLogger(__name__)
-
-async def _validate_login(
-    hass: HomeAssistant, login_data: dict[str, str]
-) -> dict[str, str]:
-    """Validate login data and return any errors."""
-    api = Gazdebordeaux(
-        async_create_clientsession(hass),
-        login_data[CONF_USERNAME],
-        login_data[CONF_PASSWORD],
-    )
-    errors: dict[str, str] = {}
-    try:
-        await api.async_login()
-    except Exception:
-        errors["base"] = "invalid_auth"
-    return errors
 
 
 class GazdebordeauxOptionFlow(OptionsFlow):
@@ -39,16 +24,12 @@ class GazdebordeauxOptionFlow(OptionsFlow):
     VERSION = 1
 
     def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize options flow."""
-        # Ne PAS faire self.config_entry = config_entry
-        # HA le gère en interne via la classe parente
-        self._user_inputs: dict = {}  # Attribut d'instance
+        self._user_inputs: dict = {}
 
     async def async_step_init(
         self, user_input: dict | None = None
     ) -> ConfigFlowResult:
-        """Gestion de l'étape 'init'."""
-
+        """First step: credentials + reset statistics."""
         option_form = vol.Schema(
             {
                 vol.Required(
@@ -65,39 +46,88 @@ class GazdebordeauxOptionFlow(OptionsFlow):
                 ): bool,
                 vol.Optional(
                     HOUSE,
-                    description={"suggested_value": self.config_entry.data.get(HOUSE, "")},
+                    default=self.config_entry.data.get(HOUSE, ""),
                 ): str,
             }
         )
 
         if user_input is None:
-            _LOGGER.debug(
-                "option_flow step user (1). 1er appel : pas de user_input -> "
-                "on affiche le form user_form"
-            )
             return self.async_show_form(step_id="init", data_schema=option_form)
 
-        # 2ème appel : il y a des user_input -> on stocke le résultat
-        _LOGGER.debug(
-            "option_flow step user (2). Valeurs reçues: %s", user_input
-        )
-        # On mémorise les user_input
         self._user_inputs.update(user_input)
+        return await self.async_step_houses()
 
-        # On appelle le step de fin pour enregistrer les modifications
-        return await self.async_end()
+    async def async_step_houses(
+        self, user_input: dict | None = None
+    ) -> ConfigFlowResult:
+        """Second step: select which houses to monitor."""
+        if user_input is not None:
+            # Save selected houses
+            selected = user_input.get("selected_houses", [])
+            houses_config = [
+                h for h in self._discovered_houses if h["path"] in selected
+            ]
+            self._user_inputs[HOUSES] = houses_config
+            return await self.async_end()
+
+        # Discover houses
+        api = Gazdebordeaux(
+            async_create_clientsession(self.hass),
+            self._user_inputs.get(CONF_USERNAME, self.config_entry.data.get(CONF_USERNAME, "")),
+            self._user_inputs.get(CONF_PASSWORD, self.config_entry.data.get(CONF_PASSWORD, "")),
+        )
+
+        try:
+            await api.async_login()
+            house_paths = await api.async_load_houses()
+        except Exception:
+            _LOGGER.error("Failed to load houses", exc_info=True)
+            return await self.async_end()
+
+        # Detect type of each house
+        self._discovered_houses = []
+        options = {}
+        for path in house_paths:
+            try:
+                house_type = await api.async_detect_house_type(path)
+            except Exception:
+                house_type = "unknown"
+            label = {"gas": "Gaz", "elec": "Électricité"}.get(house_type, house_type)
+            self._discovered_houses.append({"path": path, "type": house_type})
+            options[path] = label
+
+        if not options:
+            return await self.async_end()
+
+        # Pre-select already configured houses
+        current = self.config_entry.options.get(HOUSES, [])
+        defaults = [h["path"] for h in current] if current else list(options.keys())
+
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    "selected_houses", default=defaults
+                ): cv.multi_select(options),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="houses",
+            data_schema=schema,
+            description_placeholders={"houses_list": ", ".join(options.values())},
+        )
 
     async def async_end(self) -> ConfigFlowResult:
-        """Finalisation et sauvegarde des modifications."""
-        _LOGGER.info(
-            "Recreation de l'entry %s. Nouvelle config : %s",
-            self.config_entry.entry_id,
-            self._user_inputs,
-        )
+        """Save config and options."""
+        # Credentials go in data
+        data = {
+            CONF_USERNAME: self._user_inputs.get(CONF_USERNAME, self.config_entry.data.get(CONF_USERNAME)),
+            CONF_PASSWORD: self._user_inputs.get(CONF_PASSWORD, self.config_entry.data.get(CONF_PASSWORD)),
+            RESET_STATISTICS: self._user_inputs.get(RESET_STATISTICS, False),
+            HOUSE: self._user_inputs.get(HOUSE, self.config_entry.data.get(HOUSE, "")),
+        }
+        self.hass.config_entries.async_update_entry(self.config_entry, data=data)
 
-        # Modification de la configEntry avec nos nouvelles valeurs
-        self.hass.config_entries.async_update_entry(
-            self.config_entry, data=self._user_inputs
-        )
-
-        return self.async_create_entry(title="", data={})
+        # Houses go in options
+        houses = self._user_inputs.get(HOUSES, self.config_entry.options.get(HOUSES, []))
+        return self.async_create_entry(title="", data={HOUSES: houses})

--- a/custom_components/gazdebordeaux/sensor.py
+++ b/custom_components/gazdebordeaux/sensor.py
@@ -1,20 +1,15 @@
-"""Support for Opower sensors."""
+"""Sensors for Gaz de Bordeaux integration."""
 from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Optional
 
-from .gazdebordeaux import TotalUsageRead
+from .gazdebordeaux import TotalUsageRead, HouseData, MonthlyRead
 
-from homeassistant.components.sensor.const import (
-    SensorDeviceClass,
-    SensorStateClass
-)
-from homeassistant.components.sensor import (
-    SensorEntity,
-    SensorEntityDescription
-)
+from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
+from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfEnergy, UnitOfVolume
 from homeassistant.core import HomeAssistant
@@ -29,50 +24,108 @@ from .coordinator import GdbCoordinator
 
 
 @dataclass
-class GdbEntityDescriptionMixin:
-    """Mixin values for required keys."""
-
-    value_fn: Callable[[TotalUsageRead], str | float]
+class GdbSensorMixin:
+    value_fn: Callable[[dict[str, HouseData]], Optional[float]]
 
 
 @dataclass
-class GdbEntityDescription(SensorEntityDescription, GdbEntityDescriptionMixin):
-    """Class describing Gaz de Bordeaux sensors entities."""
+class GdbSensorDescription(SensorEntityDescription, GdbSensorMixin):
+    pass
 
 
-# suggested_display_precision=0 for all sensors since
-# Opower provides 0 decimal points for all these.
-# (for the statistics in the energy dashboard Opower does provide decimal points)
+def _gas(data: dict[str, HouseData]) -> Optional[HouseData]:
+    return data.get("gas")
 
-GAS_SENSORS: tuple[GdbEntityDescription, ...] = (
-    GdbEntityDescription(
+def _elec(data: dict[str, HouseData]) -> Optional[HouseData]:
+    return data.get("elec")
+
+
+# --- Gas sensors (backward compat, same keys as before) ---
+GAS_PERIOD_SENSORS: tuple[GdbSensorDescription, ...] = (
+    GdbSensorDescription(
         key="gas_usage_to_date",
         name="Current bill gas usage to date",
         device_class=SensorDeviceClass.GAS,
         native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
-        suggested_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
         state_class=SensorStateClass.TOTAL,
         suggested_display_precision=0,
-        value_fn=lambda data: data.volumeOfEnergy,
+        value_fn=lambda d: _gas(d).total.volumeOfEnergy if _gas(d) else None,
     ),
-    GdbEntityDescription(
+    GdbSensorDescription(
         key="gas_energy_to_date",
         name="Current energy usage to date",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL,
         suggested_display_precision=0,
-        value_fn=lambda data: data.amountOfEnergy,
+        value_fn=lambda d: _gas(d).total.amountOfEnergy if _gas(d) else None,
     ),
-    GdbEntityDescription(
+    GdbSensorDescription(
         key="gas_cost_to_date",
         name="Current bill gas cost to date",
         device_class=SensorDeviceClass.MONETARY,
         native_unit_of_measurement="€",
         state_class=SensorStateClass.TOTAL,
         suggested_display_precision=0,
-        value_fn=lambda data: data.price,
+        value_fn=lambda d: _gas(d).total.price if _gas(d) else None,
+    ),
+)
+
+# --- Elec sensors (new) ---
+ELEC_PERIOD_SENSORS: tuple[GdbSensorDescription, ...] = (
+    GdbSensorDescription(
+        key="elec_usage_to_date",
+        name="Current elec usage to date",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL,
+        suggested_display_precision=0,
+        value_fn=lambda d: _elec(d).total.amountOfEnergy if _elec(d) else None,
+    ),
+    GdbSensorDescription(
+        key="elec_cost_to_date",
+        name="Current elec cost to date",
+        device_class=SensorDeviceClass.MONETARY,
+        native_unit_of_measurement="€",
+        state_class=SensorStateClass.TOTAL,
+        suggested_display_precision=0,
+        value_fn=lambda d: _elec(d).total.price if _elec(d) else None,
+    ),
+)
+
+# --- Monthly sensors (new) ---
+MONTHLY_SENSORS: tuple[GdbSensorDescription, ...] = (
+    GdbSensorDescription(
+        key="gas_current_month_cost",
+        name="GdB gas current month cost",
+        device_class=SensorDeviceClass.MONETARY,
+        native_unit_of_measurement="€",
+        suggested_display_precision=2,
+        value_fn=lambda d: _gas(d).current_month.price if _gas(d) and _gas(d).current_month else None,
+    ),
+    GdbSensorDescription(
+        key="gas_previous_month_cost",
+        name="GdB gas previous month cost",
+        device_class=SensorDeviceClass.MONETARY,
+        native_unit_of_measurement="€",
+        suggested_display_precision=2,
+        value_fn=lambda d: _gas(d).previous_month.price if _gas(d) and _gas(d).previous_month else None,
+    ),
+    GdbSensorDescription(
+        key="elec_current_month_cost",
+        name="GdB elec current month cost",
+        device_class=SensorDeviceClass.MONETARY,
+        native_unit_of_measurement="€",
+        suggested_display_precision=2,
+        value_fn=lambda d: _elec(d).current_month.price if _elec(d) and _elec(d).current_month else None,
+    ),
+    GdbSensorDescription(
+        key="elec_previous_month_cost",
+        name="GdB elec previous month cost",
+        device_class=SensorDeviceClass.MONETARY,
+        native_unit_of_measurement="€",
+        suggested_display_precision=2,
+        value_fn=lambda d: _elec(d).previous_month.price if _elec(d) and _elec(d).previous_month else None,
     ),
 )
 
@@ -80,92 +133,72 @@ GAS_SENSORS: tuple[GdbEntityDescription, ...] = (
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Set up the Gdb sensor."""
-
     coordinator: GdbCoordinator = hass.data[DOMAIN][entry.entry_id]
     entities: list[GdbSensor | GdbLastUpdateSensor] = []
 
-    device_id = f"gazpar"
+    device_id = "gazpar"
     device = DeviceInfo(
         identifiers={(DOMAIN, device_id)},
-        name=f"Gaz de Bordeaux",
+        name="Gaz de Bordeaux",
         manufacturer="Regaz",
         model="gazpar",
         entry_type=DeviceEntryType.SERVICE,
     )
-    sensors: tuple[GdbEntityDescription, ...] = GAS_SENSORS
-    for sensor in sensors:
-        entities.append(
-            GdbSensor(
-                coordinator,
-                sensor,
-                "",
-                device,
-                device_id,
-            )
-        )
 
-    # Ajout du sensor de dernière actualisation
-    entities.append(
-        GdbLastUpdateSensor(coordinator, device, device_id)
-    )
+    # Always create gas period sensors (backward compat)
+    for desc in GAS_PERIOD_SENSORS:
+        entities.append(GdbSensor(coordinator, desc, device, device_id))
 
+    # Create elec + monthly sensors if multi-house is configured
+    houses = entry.options.get("houses", [])
+    has_elec = any(h.get("type") == "elec" for h in houses)
+    has_gas = any(h.get("type") == "gas" for h in houses)
+
+    if has_elec:
+        for desc in ELEC_PERIOD_SENSORS:
+            entities.append(GdbSensor(coordinator, desc, device, device_id))
+
+    if houses:
+        for desc in MONTHLY_SENSORS:
+            # Only create sensors for house types that are configured
+            if desc.key.startswith("gas_") and not has_gas:
+                continue
+            if desc.key.startswith("elec_") and not has_elec:
+                continue
+            entities.append(GdbSensor(coordinator, desc, device, device_id))
+
+    entities.append(GdbLastUpdateSensor(coordinator, device, device_id))
     async_add_entities(entities)
 
 
 class GdbSensor(CoordinatorEntity[GdbCoordinator], SensorEntity):
-    """Representation of an Gdb sensor."""
+    entity_description: GdbSensorDescription
 
-    entity_description: GdbEntityDescription
-
-    def __init__(
-        self,
-        coordinator: GdbCoordinator,
-        description: GdbEntityDescription,
-        utility_account_id: str,
-        device: DeviceInfo,
-        device_id: str,
-    ) -> None:
-        """Initialize the sensor."""
+    def __init__(self, coordinator, description, device, device_id):
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{device_id}_{description.key}"
         self._attr_device_info = device
-        self.utility_account_id = utility_account_id
 
     @property
     def native_value(self) -> StateType:
-        """Return the state."""
         if self.coordinator.data is not None:
-            return self.entity_description.value_fn(
-                self.coordinator.data
-            )
+            return self.entity_description.value_fn(self.coordinator.data)
         return None
 
 
-# Nouveau sensor de dernière actualisation
 class GdbLastUpdateSensor(CoordinatorEntity[GdbCoordinator], SensorEntity):
-    """Sensor affichant la date de dernière actualisation."""
-
     _attr_name = "Gaz de Bordeaux Last Update"
     _attr_device_class = SensorDeviceClass.TIMESTAMP
     _attr_icon = "mdi:clock-check"
 
-    def __init__(
-        self,
-        coordinator: GdbCoordinator,
-        device: DeviceInfo,
-        device_id: str,
-    ) -> None:
-        """Initialize the sensor."""
+    def __init__(self, coordinator, device, device_id):
         super().__init__(coordinator)
         self._attr_unique_id = f"{device_id}_last_update"
         self._attr_device_info = device
 
     @property
     def native_value(self) -> datetime | None:
-        """Return the last update datetime."""
         if self.coordinator.last_update is None:
             return None
-        # HA exige un datetime avec timezone pour SensorDeviceClass.TIMESTAMP
         return dt_util.as_local(self.coordinator.last_update)


### PR DESCRIPTION
Salut,

Mon compte GdB a 2 maisons (une pour le gaz, une pour l'élec). Le plugin ne requêtait que la `selectedHouse`, du coup je n'avais que le gaz dans HA.

## Ce que j'ai fait

- À l'installation, après le login, on peut choisir quelles maisons activer (checkboxes "Gaz" / "Électricité")
- Pareil dans les options (Configurer) pour changer après coup
- La détection gaz/élec est auto : si `volumeOfEnergy > 0` c'est du gaz, sinon de l'élec
- Nouveaux sensors pour l'élec (période) et les coûts mensuels (gaz + élec)
- Les sensors gaz existants ne changent pas

## Nouveaux sensors

- `current_elec_usage_to_date` (kWh)
- `current_elec_cost_to_date` (€)
- `gdb_gas_current_month_cost` / `gdb_gas_previous_month_cost` (€)
- `gdb_elec_current_month_cost` / `gdb_elec_previous_month_cost` (€)

Les montants mensuels viennent directement de l'API (`price` dans la vue annuelle), donc ils correspondent exactement à ce qu'on voit sur life.gazdebordeaux.fr.

Testé sur mon instance, tout fonctionne.