### PR TITLE
feat: support multi-house (gaz + élec)

### DIFF
--- a/custom_components/gazdebordeaux/__init__.py
+++ b/custom_components/gazdebordeaux/__init__.py
@@ -14,13 +14,19 @@ PLATFORMS: list[Platform] = [Platform.SENSOR]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Gaz de Bordeaux from a config entry."""
 
-    coordinator = GdbCoordinator(hass, entry.data)
+    coordinator = GdbCoordinator(hass, entry.data, entry.options)
     await coordinator.async_config_entry_first_refresh()
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
     return True
+
+
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload when options change."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/gazdebordeaux/config_flow.py
+++ b/custom_components/gazdebordeaux/config_flow.py
@@ -10,9 +10,10 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigEntry, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
-from .const import DOMAIN
+from .const import DOMAIN, HOUSES
 from .gazdebordeaux import Gazdebordeaux
 from .option_flow import GazdebordeauxOptionFlow
 
@@ -51,30 +52,74 @@ class GazdebordeauxConfigFlow(ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize a new GazdebordeauxConfigFlow."""
         self.reauth_entry: ConfigEntry | None = None
-        self.utility_info: dict[str, Any] | None = None
+        self._user_data: dict[str, Any] = {}
+        self._api: Gazdebordeaux | None = None
+        self._discovered_houses: list[dict] = []
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle the initial step."""
+        """Step 1: login."""
         errors: dict[str, str] = {}
         if user_input is not None:
-
-            errors = await _validate_login(self.hass, user_input)
+            self._api = Gazdebordeaux(
+                async_create_clientsession(self.hass),
+                user_input[CONF_USERNAME],
+                user_input[CONF_PASSWORD],
+            )
+            try:
+                await self._api.async_login()
+            except Exception:
+                errors["base"] = "invalid_auth"
             if not errors:
-                return self._async_create_gazdebordeaux_entry(user_input)
+                self._user_data = user_input
+                return await self.async_step_houses()
 
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
         )
 
+    async def async_step_houses(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Step 2: select houses."""
+        if user_input is not None:
+            selected = user_input.get("selected_houses", [])
+            houses_config = [h for h in self._discovered_houses if h["path"] in selected]
+            return self.async_create_entry(
+                title=f"({self._user_data[CONF_USERNAME]})",
+                data=self._user_data,
+                options={HOUSES: houses_config},
+            )
 
-    @callback
-    def _async_create_gazdebordeaux_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
-        """Create the config entry."""
-        return self.async_create_entry(
-            title=f"({data[CONF_USERNAME]})",
-            data=data,
+        # Discover houses
+        try:
+            house_paths = await self._api.async_load_all_houses()
+        except Exception:
+            _LOGGER.error("Failed to load houses", exc_info=True)
+            return self.async_create_entry(
+                title=f"({self._user_data[CONF_USERNAME]})", data=self._user_data)
+
+        self._discovered_houses = []
+        options = {}
+        for path in house_paths:
+            try:
+                house_type = await self._api.async_detect_house_type(path)
+            except Exception:
+                house_type = "unknown"
+            label = {"gas": "Gaz", "elec": "Électricité"}.get(house_type, house_type)
+            self._discovered_houses.append({"path": path, "type": house_type})
+            options[path] = label
+
+        if not options:
+            return self.async_create_entry(
+                title=f"({self._user_data[CONF_USERNAME]})", data=self._user_data)
+
+        return self.async_show_form(
+            step_id="houses",
+            data_schema=vol.Schema({
+                vol.Required("selected_houses", default=list(options.keys())): cv.multi_select(options),
+            }),
         )
 
     @staticmethod

--- a/custom_components/gazdebordeaux/const.py
+++ b/custom_components/gazdebordeaux/const.py
@@ -3,3 +3,4 @@
 DOMAIN = "gazdebordeaux"
 RESET_STATISTICS = "reset_stats"
 HOUSE = "house"
+HOUSES = "houses"

--- a/custom_components/gazdebordeaux/coordinator.py
+++ b/custom_components/gazdebordeaux/coordinator.py
@@ -4,8 +4,8 @@ import logging
 from types import MappingProxyType
 from typing import Any, cast
 
-from .const import RESET_STATISTICS, HOUSE
-from .gazdebordeaux import Gazdebordeaux, DailyUsageRead, TotalUsageRead
+from .const import RESET_STATISTICS, HOUSE, HOUSES
+from .gazdebordeaux import Gazdebordeaux, DailyUsageRead, TotalUsageRead, HouseData
 
 from homeassistant.components.recorder.models import (
     StatisticData,
@@ -41,13 +41,14 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
-class GdbCoordinator(DataUpdateCoordinator[TotalUsageRead]):
+class GdbCoordinator(DataUpdateCoordinator[dict[str, HouseData]]):
     """Handle fetching GazdeBordeaux data, updating sensors and inserting statistics."""
 
     def __init__(
         self,
         hass: HomeAssistant,
         entry_data: MappingProxyType[str, Any],
+        entry_options: MappingProxyType[str, Any] | None = None,
     ) -> None:
         """Initialize the data handler."""
         super().__init__(
@@ -104,29 +105,49 @@ class GdbCoordinator(DataUpdateCoordinator[TotalUsageRead]):
         # _async_update_data not periodically getting called which is needed for _insert_statistics.
         self.async_add_listener(_dummy_listener)
 
+        # Houses to query (from options, or fallback to selectedHouse)
+        self._configured_houses: list[dict] = []
+        if entry_options and HOUSES in entry_options:
+            self._configured_houses = entry_options[HOUSES]
+
     async def _async_update_data(
         self,
-    ) -> TotalUsageRead:
-        """Fetch data from API endpoint."""
+    ) -> dict[str, HouseData]:
+        """Fetch data from all configured houses."""
         try:
-            # Login expires after a few minutes.
-            # Given the infrequent updating (every 12h)
-            # assume previous session has expired and re-login.
             await self.api.async_login()
         except Exception as err:
             raise ConfigEntryAuthFailed from err
 
-        totalUsage: TotalUsageRead = await self.api.async_get_total_usage()
+        houses_data: dict[str, HouseData] = {}
 
-        # Because Opower provides historical usage/cost with a delay of a couple of days
-        # we need to insert data into statistics.
-        await self._insert_statistics()
+        if self._configured_houses:
+            for h in self._configured_houses:
+                try:
+                    data = await self.api.async_get_house_data(h["path"])
+                    houses_data[data.house_type] = data
+                except Exception:
+                    _LOGGER.error("Error fetching house %s", h["path"], exc_info=True)
+        else:
+            # Legacy mode: single house
+            try:
+                totalUsage = await self.api.async_get_total_usage()
+                houses_data["gas"] = HouseData(
+                    house_type="gas", total=totalUsage,
+                    current_month=None, previous_month=None,
+                )
+            except Exception:
+                _LOGGER.error("Error fetching default house", exc_info=True)
+
+        # Statistics import (gas only, backward compat)
+        if "gas" in houses_data:
+            await self._insert_statistics()
 
         # Mise à jour de la date de dernière actualisation
         self.last_update = datetime.now()
         _LOGGER.debug("Last update: %s", self.last_update.strftime("%Y-%m-%d %H:%M:%S"))
 
-        return totalUsage
+        return houses_data
 
     async def _insert_statistics(self) -> None:
         """Insert gdb statistics."""

--- a/custom_components/gazdebordeaux/gazdebordeaux.py
+++ b/custom_components/gazdebordeaux/gazdebordeaux.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import pytz
 from aiohttp import ClientSession
 from json.decoder import JSONDecodeError
-from typing import List, Any
+from typing import List, Any, Optional
 
 DATA_URL = "https://life.gazdebordeaux.fr{0}/consumptions"
 LOGIN_URL = "https://life.gazdebordeaux.fr/api/login_check"
@@ -37,6 +37,22 @@ class TotalUsageRead:
     amountOfEnergy: float
     volumeOfEnergy: float
     price: float
+
+@dataclasses.dataclass
+class MonthlyRead:
+    kwh: float
+    price: float
+    volumeOfEnergy: float
+    contractPrice: float
+    consumptionPrice: float
+
+@dataclasses.dataclass
+class HouseData:
+    """All data for one house."""
+    house_type: str  # "gas" or "elec"
+    total: TotalUsageRead
+    current_month: Optional[MonthlyRead]
+    previous_month: Optional[MonthlyRead]
 
 @dataclasses.dataclass
 class DailyUsageRead:
@@ -228,3 +244,78 @@ class Gazdebordeaux:
         Logger.debug("Fetching house %s", url)
         async with self._session.get(url, headers=self._authenticated_headers()) as response:
             return await response.json(content_type=None)
+
+    # --- Multi-house support ---
+
+    async def async_load_all_houses(self) -> List[str]:
+        """Return all house paths from the user profile."""
+        if self._token is None:
+            await self.async_login()
+        async with self._session.get(ME_URL, headers=self._authenticated_headers()) as response:
+            data = await response.json()
+            return data.get("houses", [])
+
+    async def async_detect_house_type(self, house_path: str) -> str:
+        """Detect if a house is gas or elec by checking volumeOfEnergy."""
+        yearly = await self.async_get_data_for_house(house_path, None, None, "year")
+        total = yearly.get("total", {})
+        return "gas" if total.get("volumeOfEnergy", 0) > 0 else "elec"
+
+    async def async_get_house_data(self, house_path: str) -> HouseData:
+        """Fetch yearly data for a house and return structured data."""
+        yearly = await self.async_get_data_for_house(house_path, None, None, "year")
+        total_raw = yearly["total"]
+        total = TotalUsageRead(
+            amountOfEnergy=total_raw.get("kwh", 0),
+            volumeOfEnergy=total_raw.get("volumeOfEnergy", 0),
+            price=total_raw.get("price", 0),
+        )
+        house_type = "gas" if total.volumeOfEnergy > 0 else "elec"
+        current, previous = self._extract_monthly(yearly)
+        return HouseData(house_type=house_type, total=total,
+                         current_month=current, previous_month=previous)
+
+    async def async_get_data_for_house(self, house_path, start, end, scale) -> Any:
+        """Fetch data for a specific house (not necessarily the selected one)."""
+        if self._token is None:
+            await self.async_login()
+        house = house_path or ""
+        if not house.startswith("/api/"):
+            if not house.startswith("/"):
+                house = "/" + house
+            house = "/api" + house
+        url = DATA_URL.format(house)
+        params = {"scale": scale}
+        if start is not None:
+            params["startDate"] = start.strftime("%Y-%m-%d")
+        if end is not None:
+            params["endDate"] = end.strftime("%Y-%m-%d")
+        async with self._session.get(url, headers=self._authenticated_headers(), params=params) as response:
+            return await response.json(content_type=None)
+
+    def _extract_monthly(self, yearly_data: dict):
+        """Extract current and previous month from yearly API response."""
+        now = datetime.now(paris_tz)
+        current_key = now.strftime("%Y-%m")
+        prev_month = now.month - 1 or 12
+        prev_year = now.year if now.month > 1 else now.year - 1
+        prev_key = f"{prev_year}-{prev_month:02d}"
+        current = None
+        previous = None
+        for key, val in yearly_data.items():
+            if key == "total" or not isinstance(val, dict):
+                continue
+            if key == current_key:
+                current = self._parse_monthly(val)
+            elif key == prev_key:
+                previous = self._parse_monthly(val)
+        return current, previous
+
+    @staticmethod
+    def _parse_monthly(data: dict) -> MonthlyRead:
+        return MonthlyRead(
+            kwh=data.get("kwh", 0), price=data.get("price", 0),
+            volumeOfEnergy=data.get("volumeOfEnergy", 0),
+            contractPrice=data.get("contractPrice", 0),
+            consumptionPrice=data.get("consumptionPrice", 0),
+        )

--- a/custom_components/gazdebordeaux/option_flow.py
+++ b/custom_components/gazdebordeaux/option_flow.py
@@ -11,7 +11,8 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
-from .const import DOMAIN, RESET_STATISTICS, HOUSE
+from homeassistant.helpers import config_validation as cv
+from .const import DOMAIN, RESET_STATISTICS, HOUSE, HOUSES
 from .gazdebordeaux import Gazdebordeaux
 
 _LOGGER = logging.getLogger(__name__)
@@ -84,20 +85,65 @@ class GazdebordeauxOptionFlow(OptionsFlow):
         # On mémorise les user_input
         self._user_inputs.update(user_input)
 
-        # On appelle le step de fin pour enregistrer les modifications
-        return await self.async_end()
+        # On passe à la sélection des maisons
+        return await self.async_step_houses()
+
+    async def async_step_houses(
+        self, user_input: dict | None = None
+    ) -> ConfigFlowResult:
+        """Select which houses to monitor."""
+        if user_input is not None:
+            selected = user_input.get("selected_houses", [])
+            houses_config = [h for h in self._discovered_houses if h["path"] in selected]
+            self._user_inputs[HOUSES] = houses_config
+            return await self.async_end()
+
+        # Discover houses
+        api = Gazdebordeaux(
+            async_create_clientsession(self.hass),
+            self._user_inputs.get(CONF_USERNAME, self.config_entry.data.get(CONF_USERNAME, "")),
+            self._user_inputs.get(CONF_PASSWORD, self.config_entry.data.get(CONF_PASSWORD, "")),
+        )
+        try:
+            await api.async_login()
+            house_paths = await api.async_load_all_houses()
+        except Exception:
+            _LOGGER.error("Failed to load houses", exc_info=True)
+            return await self.async_end()
+
+        self._discovered_houses = []
+        options = {}
+        for path in house_paths:
+            try:
+                house_type = await api.async_detect_house_type(path)
+            except Exception:
+                house_type = "unknown"
+            label = {"gas": "Gaz", "elec": "Électricité"}.get(house_type, house_type)
+            self._discovered_houses.append({"path": path, "type": house_type})
+            options[path] = label
+
+        if not options:
+            return await self.async_end()
+
+        current = self.config_entry.options.get(HOUSES, [])
+        defaults = [h["path"] for h in current] if current else list(options.keys())
+
+        return self.async_show_form(
+            step_id="houses",
+            data_schema=vol.Schema({
+                vol.Required("selected_houses", default=defaults): cv.multi_select(options),
+            }),
+        )
 
     async def async_end(self) -> ConfigFlowResult:
-        """Finalisation et sauvegarde des modifications."""
-        _LOGGER.info(
-            "Recreation de l'entry %s. Nouvelle config : %s",
-            self.config_entry.entry_id,
-            self._user_inputs,
-        )
+        """Save config and options."""
+        data = {
+            CONF_USERNAME: self._user_inputs.get(CONF_USERNAME, self.config_entry.data.get(CONF_USERNAME)),
+            CONF_PASSWORD: self._user_inputs.get(CONF_PASSWORD, self.config_entry.data.get(CONF_PASSWORD)),
+            RESET_STATISTICS: self._user_inputs.get(RESET_STATISTICS, False),
+            HOUSE: self._user_inputs.get(HOUSE, self.config_entry.data.get(HOUSE, "")),
+        }
+        self.hass.config_entries.async_update_entry(self.config_entry, data=data)
 
-        # Modification de la configEntry avec nos nouvelles valeurs
-        self.hass.config_entries.async_update_entry(
-            self.config_entry, data=self._user_inputs
-        )
-
-        return self.async_create_entry(title="", data={})
+        houses = self._user_inputs.get(HOUSES, self.config_entry.options.get(HOUSES, []))
+        return self.async_create_entry(title="", data={HOUSES: houses})

--- a/custom_components/gazdebordeaux/sensor.py
+++ b/custom_components/gazdebordeaux/sensor.py
@@ -5,7 +5,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 
-from .gazdebordeaux import TotalUsageRead
+from typing import Optional
+from .gazdebordeaux import TotalUsageRead, HouseData
 
 from homeassistant.components.sensor.const import (
     SensorDeviceClass,
@@ -32,7 +33,7 @@ from .coordinator import GdbCoordinator
 class GdbEntityDescriptionMixin:
     """Mixin values for required keys."""
 
-    value_fn: Callable[[TotalUsageRead], str | float]
+    value_fn: Callable[[dict[str, HouseData]], Optional[float]]
 
 
 @dataclass
@@ -44,6 +45,12 @@ class GdbEntityDescription(SensorEntityDescription, GdbEntityDescriptionMixin):
 # Opower provides 0 decimal points for all these.
 # (for the statistics in the energy dashboard Opower does provide decimal points)
 
+def _gas(data: dict[str, HouseData]) -> Optional[HouseData]:
+    return data.get("gas")
+
+def _elec(data: dict[str, HouseData]) -> Optional[HouseData]:
+    return data.get("elec")
+
 GAS_SENSORS: tuple[GdbEntityDescription, ...] = (
     GdbEntityDescription(
         key="gas_usage_to_date",
@@ -53,7 +60,7 @@ GAS_SENSORS: tuple[GdbEntityDescription, ...] = (
         suggested_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
         state_class=SensorStateClass.TOTAL,
         suggested_display_precision=0,
-        value_fn=lambda data: data.volumeOfEnergy,
+        value_fn=lambda d: _gas(d).total.volumeOfEnergy if _gas(d) else None,
     ),
     GdbEntityDescription(
         key="gas_energy_to_date",
@@ -63,7 +70,7 @@ GAS_SENSORS: tuple[GdbEntityDescription, ...] = (
         suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL,
         suggested_display_precision=0,
-        value_fn=lambda data: data.amountOfEnergy,
+        value_fn=lambda d: _gas(d).total.amountOfEnergy if _gas(d) else None,
     ),
     GdbEntityDescription(
         key="gas_cost_to_date",
@@ -72,7 +79,63 @@ GAS_SENSORS: tuple[GdbEntityDescription, ...] = (
         native_unit_of_measurement="€",
         state_class=SensorStateClass.TOTAL,
         suggested_display_precision=0,
-        value_fn=lambda data: data.price,
+        value_fn=lambda d: _gas(d).total.price if _gas(d) else None,
+    ),
+)
+
+ELEC_SENSORS: tuple[GdbEntityDescription, ...] = (
+    GdbEntityDescription(
+        key="elec_usage_to_date",
+        name="Current elec usage to date",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL,
+        suggested_display_precision=0,
+        value_fn=lambda d: _elec(d).total.amountOfEnergy if _elec(d) else None,
+    ),
+    GdbEntityDescription(
+        key="elec_cost_to_date",
+        name="Current elec cost to date",
+        device_class=SensorDeviceClass.MONETARY,
+        native_unit_of_measurement="€",
+        state_class=SensorStateClass.TOTAL,
+        suggested_display_precision=0,
+        value_fn=lambda d: _elec(d).total.price if _elec(d) else None,
+    ),
+)
+
+MONTHLY_SENSORS: tuple[GdbEntityDescription, ...] = (
+    GdbEntityDescription(
+        key="gas_current_month_cost",
+        name="GdB gas current month cost",
+        device_class=SensorDeviceClass.MONETARY,
+        native_unit_of_measurement="€",
+        suggested_display_precision=2,
+        value_fn=lambda d: _gas(d).current_month.price if _gas(d) and _gas(d).current_month else None,
+    ),
+    GdbEntityDescription(
+        key="gas_previous_month_cost",
+        name="GdB gas previous month cost",
+        device_class=SensorDeviceClass.MONETARY,
+        native_unit_of_measurement="€",
+        suggested_display_precision=2,
+        value_fn=lambda d: _gas(d).previous_month.price if _gas(d) and _gas(d).previous_month else None,
+    ),
+    GdbEntityDescription(
+        key="elec_current_month_cost",
+        name="GdB elec current month cost",
+        device_class=SensorDeviceClass.MONETARY,
+        native_unit_of_measurement="€",
+        suggested_display_precision=2,
+        value_fn=lambda d: _elec(d).current_month.price if _elec(d) and _elec(d).current_month else None,
+    ),
+    GdbEntityDescription(
+        key="elec_previous_month_cost",
+        name="GdB elec previous month cost",
+        device_class=SensorDeviceClass.MONETARY,
+        native_unit_of_measurement="€",
+        suggested_display_precision=2,
+        value_fn=lambda d: _elec(d).previous_month.price if _elec(d) and _elec(d).previous_month else None,
     ),
 )
 
@@ -93,22 +156,28 @@ async def async_setup_entry(
         model="gazpar",
         entry_type=DeviceEntryType.SERVICE,
     )
-    sensors: tuple[GdbEntityDescription, ...] = GAS_SENSORS
-    for sensor in sensors:
-        entities.append(
-            GdbSensor(
-                coordinator,
-                sensor,
-                "",
-                device,
-                device_id,
-            )
-        )
+    # Gas period sensors (always, backward compat)
+    for desc in GAS_SENSORS:
+        entities.append(GdbSensor(coordinator, desc, "", device, device_id))
 
-    # Ajout du sensor de dernière actualisation
-    entities.append(
-        GdbLastUpdateSensor(coordinator, device, device_id)
-    )
+    # Elec + monthly sensors (if multi-house configured)
+    houses = entry.options.get("houses", [])
+    has_elec = any(h.get("type") == "elec" for h in houses)
+    has_gas = any(h.get("type") == "gas" for h in houses)
+
+    if has_elec:
+        for desc in ELEC_SENSORS:
+            entities.append(GdbSensor(coordinator, desc, "", device, device_id))
+
+    if houses:
+        for desc in MONTHLY_SENSORS:
+            if desc.key.startswith("gas_") and not has_gas:
+                continue
+            if desc.key.startswith("elec_") and not has_elec:
+                continue
+            entities.append(GdbSensor(coordinator, desc, "", device, device_id))
+
+    entities.append(GdbLastUpdateSensor(coordinator, device, device_id))
 
     async_add_entities(entities)
 


### PR DESCRIPTION
Salut,

J'ai rebasé sur le dernier main (v1.1.10) et nettoyé le diff. Plus de conflits.

Mon compte GdB a 2 maisons (une pour le gaz, une pour l'élec). Le plugin ne requêtait que la `selectedHouse`, du coup je n'avais que le gaz dans HA.

## Ce que j'ai fait

- À l'installation, après le login, on peut choisir quelles maisons activer (checkboxes "Gaz" / "Électricité")
- Pareil dans les options (Configurer) pour changer après coup
- La détection gaz/élec est auto : si `volumeOfEnergy > 0` c'est du gaz, sinon de l'élec
- Nouveaux sensors pour l'élec (période) et les coûts mensuels (gaz + élec)
- Les sensors gaz existants ne changent pas

## Nouveaux sensors

- `current_elec_usage_to_date` (kWh)
- `current_elec_cost_to_date` (€)
- `gdb_gas_current_month_cost` / `gdb_gas_previous_month_cost` (€)
- `gdb_elec_current_month_cost` / `gdb_elec_previous_month_cost` (€)

Les montants mensuels viennent directement de l'API (price dans la vue annuelle), donc ils correspondent exactement à ce qu'on voit sur life.gazdebordeaux.fr.

Testé sur mon instance, tout fonctionne.