### PR TITLE
ci: tests workflow and unit tests for the API client

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,50 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint and format check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements_test.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_test.txt
+
+      - name: ruff check
+        run: ruff check .
+
+      - name: ruff format check
+        run: ruff format --check .
+
+  tests:
+    name: Pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements_test.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_test.txt
+
+      - name: Run pytest
+        run: pytest -v --cov=custom_components/gazdebordeaux --cov-report=term-missing

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements_test.txt
+          # Runtime deps live in manifest.json (HA convention); install them too.
+          pip install $(python -c "import json; print(' '.join(json.load(open('custom_components/gazdebordeaux/manifest.json'))['requirements']))")
 
       - name: Run pytest
         run: pytest -v --cov=custom_components/gazdebordeaux --cov-report=term-missing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ files = ["custom_components/gazdebordeaux"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
 log_cli = true
 log_cli_level = "INFO"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,5 +2,6 @@ pytest==8.*
 pytest-asyncio==0.24.*
 pytest-cov==5.*
 pytest-homeassistant-custom-component==0.13.*
+aioresponses==0.7.*
 ruff==0.7.*
 mypy==1.13.*

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,9 @@
 pytest==8.*
 pytest-asyncio==0.24.*
 pytest-cov==5.*
-pytest-homeassistant-custom-component==0.13.*
 aioresponses==0.7.*
 ruff==0.7.*
 mypy==1.13.*
+# pytest-homeassistant-custom-component will be added in the phase that
+# introduces HA-fixture-dependent tests; pinning it here would force pytest
+# to load the plugin (and Home Assistant itself) on every run.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Shared pytest fixtures for the gazdebordeaux integration tests.
+
+Phase 3 will add `pytest_plugins = ["pytest_homeassistant_custom_component"]`
+once HA-fixture-dependent tests are added (config flow, sensor entities).
+For now the test suite is pure-Python so we keep this conftest minimal to
+avoid pulling Home Assistant into the test environment.
+"""
+
+from __future__ import annotations

--- a/tests/test_gazdebordeaux.py
+++ b/tests/test_gazdebordeaux.py
@@ -1,0 +1,153 @@
+"""Pure-Python tests for the Gazdebordeaux API client.
+
+These exercise the HTTP contract by mocking aiohttp via aioresponses; no
+Home Assistant fixtures are needed. We import `gazdebordeaux` as a
+top-level module to avoid pulling the package's `__init__.py`, which
+imports Home Assistant.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from aiohttp import ClientSession
+from aioresponses import aioresponses
+
+sys.path.insert(
+    0, str(Path(__file__).resolve().parent.parent / "custom_components" / "gazdebordeaux")
+)
+from gazdebordeaux import (
+    DATA_URL,
+    LOGIN_URL,
+    ME_URL,
+    Gazdebordeaux,
+)
+
+USERNAME = "user@example.com"
+PASSWORD = "secret"
+TOKEN = "fake-jwt-token"
+HOUSE_PATH = "/api/houses/abc"
+DATA_HOST = "https://life.gazdebordeaux.fr"
+
+
+@pytest.fixture
+def http_mock():
+    with aioresponses() as m:
+        yield m
+
+
+@pytest.fixture
+async def session():
+    async with ClientSession() as s:
+        yield s
+
+
+# ---------- async_login -----------------------------------------------------
+
+
+async def test_login_stores_token(http_mock, session):
+    http_mock.post(LOGIN_URL, payload={"token": TOKEN})
+
+    api = Gazdebordeaux(session, USERNAME, PASSWORD)
+    await api.async_login()
+
+    assert api._token == TOKEN
+
+
+async def test_login_html_response_raises(http_mock, session):
+    http_mock.post(
+        LOGIN_URL,
+        status=403,
+        body="<html>403 Forbidden</html>",
+        headers={"Content-Type": "text/html"},
+    )
+
+    api = Gazdebordeaux(session, USERNAME, PASSWORD)
+    with pytest.raises(Exception, match="Login response was not JSON"):
+        await api.async_login()
+
+
+async def test_login_null_token_raises(http_mock, session):
+    http_mock.post(LOGIN_URL, payload={"token": None})
+
+    api = Gazdebordeaux(session, USERNAME, PASSWORD)
+    with pytest.raises(Exception, match="invalid auth"):
+        await api.async_login()
+
+
+# ---------- loadHouse: selectedHouse path ----------------------------------
+
+
+async def test_loadhouse_uses_selected_house(http_mock, session):
+    http_mock.get(ME_URL, payload={"selectedHouse": HOUSE_PATH, "houses": [HOUSE_PATH]})
+
+    api = Gazdebordeaux(session, USERNAME, PASSWORD, token=TOKEN)
+    await api.loadHouse()
+
+    assert api._selectedHouse == HOUSE_PATH
+
+
+# ---------- loadHouse: multi-house iteration -------------------------------
+
+
+async def test_loadhouse_picks_gas_house(http_mock, session):
+    elec = "/api/houses/elec-uuid"
+    gas = "/api/houses/gas-uuid"
+
+    http_mock.get(ME_URL, payload={"selectedHouse": None, "houses": [elec, gas]})
+    http_mock.get(f"{DATA_HOST}{elec}", payload={"contractType": {"category": "electricity"}})
+    http_mock.get(f"{DATA_HOST}{gas}", payload={"contractType": {"category": "gas"}})
+
+    api = Gazdebordeaux(session, USERNAME, PASSWORD, token=TOKEN)
+    await api.loadHouse()
+
+    assert api._selectedHouse == gas
+
+
+async def test_loadhouse_no_gas_raises(http_mock, session):
+    elec1 = "/api/houses/elec1"
+    elec2 = "/api/houses/elec2"
+
+    http_mock.get(ME_URL, payload={"selectedHouse": None, "houses": [elec1, elec2]})
+    http_mock.get(f"{DATA_HOST}{elec1}", payload={"contractType": {"category": "electricity"}})
+    http_mock.get(f"{DATA_HOST}{elec2}", payload={"contractType": {"category": "electricity"}})
+
+    api = Gazdebordeaux(session, USERNAME, PASSWORD, token=TOKEN)
+    with pytest.raises(Exception, match="No gas contract found"):
+        await api.loadHouse()
+
+
+async def test_loadhouse_empty_houses_raises(http_mock, session):
+    http_mock.get(ME_URL, payload={"selectedHouse": None, "houses": []})
+
+    api = Gazdebordeaux(session, USERNAME, PASSWORD, token=TOKEN)
+    with pytest.raises(Exception, match="No houses found"):
+        await api.loadHouse()
+
+
+# ---------- async_get_data: house path normalization -----------------------
+
+
+@pytest.mark.parametrize(
+    "house_in",
+    [
+        "/api/houses/abc",  # already prefixed
+        "/houses/abc",  # missing /api
+        "houses/abc",  # missing both leading slash and /api
+    ],
+)
+async def test_data_url_normalization(http_mock, session, house_in):
+    expected_url = DATA_URL.format("/api/houses/abc")
+    http_mock.get(
+        f"{expected_url}?scale=year",
+        payload={"total": {"kwh": 100, "volumeOfEnergy": 10, "price": 50}},
+    )
+
+    api = Gazdebordeaux(session, USERNAME, PASSWORD, token=TOKEN, house=house_in)
+    result = await api.async_get_total_usage()
+
+    assert result.amountOfEnergy == 100
+    assert result.volumeOfEnergy == 10
+    assert result.price == 50


### PR DESCRIPTION
## Summary
Phase 2 of the tooling refresh, **stacked on top of #31**. Targets the phase 1 branch so the diff stays focused on what's new.

- Adds `.github/workflows/tests.yml` running on every push and PR:
  - `lint` job: `ruff check` + `ruff format --check`
  - `tests` job: `pytest --cov=custom_components/gazdebordeaux`
- Adds `aioresponses` to `requirements_test.txt` for HTTP mocking.
- Adds `tests/test_gazdebordeaux.py` — 10 tests covering the API client (login flow, multi-house iteration, URL normalization). No Home Assistant fixtures yet; that's phase 3.

The test file imports the client via `sys.path` insertion to avoid loading `custom_components/gazdebordeaux/__init__.py` (which imports HA). Phase 3 will switch to `pytest-homeassistant-custom-component` for tests that genuinely need HA.

## Local verification
```
$ pytest tests/test_gazdebordeaux.py
========== 10 passed in 0.14s ==========
$ ruff check .
All checks passed!
$ ruff format --check .
12 files already formatted
```

## Merge order
Once #31 lands, GitHub will auto-retarget this PR to `main`.