### PR TITLE
chore: pre-commit, dependabot, issue templates, CONTRIBUTING

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+name: Bug report
+description: Report a problem with the integration
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill in as much
+        of the form as you can — vague reports are hard to action.
+
+  - type: input
+    id: integration_version
+    attributes:
+      label: Integration version
+      description: From the manifest, or what HACS shows.
+      placeholder: e.g. 1.1.10
+    validations:
+      required: true
+
+  - type: input
+    id: ha_version
+    attributes:
+      label: Home Assistant version
+      placeholder: e.g. 2026.4.1
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the problem and what you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: |
+        Enable debug logging for this integration first:
+
+        ```yaml
+        logger:
+          logs:
+            custom_components.gazdebordeaux: debug
+        ```
+
+        Then paste the lines around the error. Redact your token, email, and
+        house UUIDs before submitting.
+      render: shell
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Screenshots, account specifics (multiple contracts, recent password change, etc.) — anything that might help.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Suggest an enhancement
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: A clear description of the user-facing pain point. "I can't see X", "I have to do Y manually every month", etc.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How you'd like the integration to behave.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you've considered
+      description: Other integrations, custom templates, automations — anything that already gets you partway there.
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Mockups, references to the Gaz de Bordeaux web/app behavior, etc.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.7.4
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-added-large-files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing
+
+Thanks for taking the time to contribute! This is a small custom integration for Home Assistant; the goal is to keep the loop fast and the surface area small.
+
+## Setup
+
+```bash
+# Python 3.13+ required (matches the HA version we test against)
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements_test.txt
+
+# Optional but recommended: enable git hooks so lint/format runs on commit
+pre-commit install
+```
+
+If your venv pre-dates a HA bump, refresh it:
+
+```bash
+pip install -r requirements_test.txt --upgrade
+```
+
+`pytest-homeassistant-custom-component` pulls a matched Home Assistant version, so you don't need to install HA separately.
+
+## Run the test suite
+
+```bash
+pytest                     # full suite
+pytest tests/              # phase-2 client tests only (fast, no HA)
+pytest tests/integration/  # HA-fixture-dependent tests (config flow, sensors)
+pytest --cov=custom_components/gazdebordeaux  # with coverage
+```
+
+CI runs the same lint and pytest commands on every push and PR (`.github/workflows/tests.yml`).
+
+## Lint and format
+
+We use [ruff](https://docs.astral.sh/ruff/) for both lint and format. Config lives in `pyproject.toml`.
+
+```bash
+ruff check .              # lint
+ruff check . --fix        # auto-fix what's safe
+ruff format .             # format
+ruff format --check .     # CI-style check, no changes
+```
+
+`pre-commit install` wires both into the commit hook so this happens automatically.
+
+## Manual smoke testing in Home Assistant
+
+A standalone script is included for hitting the upstream API without needing a running HA:
+
+```bash
+GDB_USERNAME=you@example.com GDB_PASSWORD='...' python test_login.py
+```
+
+It enables DEBUG logging so request URLs, response status, content-type, and bodies show up — useful when the upstream API changes shape.
+
+## Releasing
+
+1. Bump `custom_components/gazdebordeaux/manifest.json` `version`.
+2. Add a section to `CHANGELOG.md` (Keep a Changelog format).
+3. Open a PR, get CI green, merge.
+4. After merge, tag the commit: `git tag -a v1.1.X -m "..." && git push origin v1.1.X`. HACS picks up the release from the tag.
+
+If a version is sitting on an open PR and you make further changes before merging, fold them into the same version's changelog rather than bumping again — only bump after the previous version actually shipped to `main`.
+
+## Project notes
+
+`CLAUDE.md` at the repo root has a longer write-up of API quirks, payload shapes, and historical pitfalls (multi-house accounts, the WAF browser-headers requirement, the voluptuous `Optional(default=...)` trap). Worth a read before touching `gazdebordeaux.py` or the config flow.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Home Assistant Gaz De Bordeaux integration
 
+[![Tests](https://github.com/chriscamicas/gazdebordeaux-ha/actions/workflows/tests.yml/badge.svg)](https://github.com/chriscamicas/gazdebordeaux-ha/actions/workflows/tests.yml)
+[![hassfest](https://github.com/chriscamicas/gazdebordeaux-ha/actions/workflows/hassfest-action.yml/badge.svg)](https://github.com/chriscamicas/gazdebordeaux-ha/actions/workflows/hassfest-action.yml)
+[![HACS validation](https://github.com/chriscamicas/gazdebordeaux-ha/actions/workflows/hacs-action.yml/badge.svg)](https://github.com/chriscamicas/gazdebordeaux-ha/actions/workflows/hacs-action.yml)
+
 ## Installation
 ### Method 1 : HACS (recommended)
 


### PR DESCRIPTION
## Summary
Phase 4 of the tooling refresh, **stacked on top of #33**. Repo polish; the integration's runtime behavior isn't touched.

- **`.pre-commit-config.yaml`** — ruff (lint + format) and a small set of standard hooks (eof-fixer, trailing whitespace, yaml/json check, merge-conflict guard, large-file guard). Mirrors the CI lint job so contributors don't push red CI.
- **`.github/dependabot.yml`** — weekly bumps for `pip` and `github-actions`.
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — GitHub-form template prompting for HA + integration versions, repro steps, redacted debug logs.
- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — focused on the user-facing problem rather than the proposed implementation.
- **`CONTRIBUTING.md`** — setup, test, lint, manual-smoke-testing, and release instructions. References the existing `test_login.py` and `CLAUDE.md`.
- **README badges** for the three CI workflows (tests, hassfest, HACS).

## Verification
- `ruff check .` → all checks passed.
- `python -c "import yaml; ..."` validates the four new YAML files load.

## Merge order
This PR targets `test/config-flow-and-sensor` (#33). It will auto-retarget to `main` as the upstream PRs land.