### PR TITLE
chore: prep for mypy — pytz stubs and dead variable redefinition

### DIFF
--- a/custom_components/gazdebordeaux/coordinator.py
+++ b/custom_components/gazdebordeaux/coordinator.py
@@ -77,10 +77,6 @@ class GdbCoordinator(DataUpdateCoordinator[TotalUsageRead]):
                 _LOGGER.debug("Asked to reset all statistics...")
                 entries = self.hass.config_entries.async_entries(DOMAIN)
 
-                house: Any = None
-                if HOUSE in entry_data:
-                    house = entry_data[HOUSE]
-
                 _LOGGER.debug("Updating config...")
                 self.hass.config_entries.async_update_entry(
                     entries[0],

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,3 +5,4 @@ pytest-homeassistant-custom-component>=0.13.300
 aioresponses==0.7.*
 ruff==0.7.*
 mypy==1.13.*
+types-pytz


### PR DESCRIPTION
## Summary
Phase 5a, **stacked on top of #34**. Two small mypy preliminaries; runtime behavior unchanged.

- **`types-pytz`** added to `requirements_test.txt` so mypy knows what `pytz.timezone(...)` returns.
- **Dropped redundant `house: Any = None` redeclaration** inside the reset-statistics branch of `GdbCoordinator.__init__`. The outer `house` from earlier in the same function is still in scope; the inner shadow was dead code (mypy flagged it as `no-redef`).

## Mypy delta
Against `custom_components/gazdebordeaux`:
- Before: 8 errors in 3 files
- After: 6 errors in 2 files (the remaining 6 are real drift between the integration and modern HA APIs — `StatisticMetaData` TypedDict and `EntityDescription` becoming frozen — and will be addressed in phase 5b before mypy lands in CI in 5c)

## Verification
```
$ pytest tests/                # 13 passed
$ ruff check .                 # All checks passed!
$ mypy custom_components/...   # 6 errors (down from 8)
```

## Merge order
Targets `chore/repo-hygiene` (#34); will auto-retarget to `main` as upstream PRs land.