### PR TITLE
refactor: align statistic metadata and entity description with modern HA (v1.1.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.11] - 2026-04-28
+- Tag the cost statistic with `unit_class="monetary"` so the energy dashboard recognizes it as a currency series (was `None` before)
+- Drop deprecated `device_class` / `state_class` / `has_mean` keys from external statistic metadata; they're no longer accepted by the recorder's `StatisticMetaData` TypedDict in modern Home Assistant
+- Refactor `GdbEntityDescription` to the modern frozen+kw_only single-dataclass pattern (the old mixin shape doesn't compose with the now-frozen `EntityDescription`)
+
 ## [1.1.10] - 2026-04-25
 - Pick the first gas-contract house automatically when the account has multiple contracts and no `selectedHouse` (e.g. gas + electricity customers)
 

--- a/custom_components/gazdebordeaux/coordinator.py
+++ b/custom_components/gazdebordeaux/coordinator.py
@@ -16,10 +16,6 @@ from homeassistant.components.recorder.statistics import (
     statistics_during_period,
 )
 from homeassistant.components.recorder.util import get_instance
-from homeassistant.components.sensor import (
-    SensorDeviceClass,
-    SensorStateClass,
-)
 from homeassistant.const import (
     CONF_PASSWORD,
     CONF_USERNAME,
@@ -205,20 +201,15 @@ class GdbCoordinator(DataUpdateCoordinator[TotalUsageRead]):
         name_prefix = " ".join(("Gaz de Bordeaux",))
 
         cost_metadata = StatisticMetaData(
-            has_mean=False,
             mean_type=StatisticMeanType.NONE,
-            # unit_class="monetary",
-            unit_class=None,
+            unit_class="monetary",
             has_sum=True,
             name=f"{name_prefix} cost",
             source=DOMAIN,
             statistic_id=cost_statistic_id,
             unit_of_measurement=CURRENCY_EURO,
-            device_class=SensorDeviceClass.MONETARY,
-            state_class=SensorStateClass.TOTAL,
         )
         consumption_metadata = StatisticMetaData(
-            has_mean=False,
             mean_type=StatisticMeanType.NONE,
             unit_class="energy",
             has_sum=True,
@@ -226,11 +217,8 @@ class GdbCoordinator(DataUpdateCoordinator[TotalUsageRead]):
             source=DOMAIN,
             statistic_id=consumption_statistic_id,
             unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-            device_class=SensorDeviceClass.ENERGY,
-            state_class=SensorStateClass.TOTAL,
         )
         volume_metadata = StatisticMetaData(
-            has_mean=False,
             mean_type=StatisticMeanType.NONE,
             unit_class="volume",
             has_sum=True,
@@ -238,8 +226,6 @@ class GdbCoordinator(DataUpdateCoordinator[TotalUsageRead]):
             source=DOMAIN,
             statistic_id=volume_statistic_id,
             unit_of_measurement=UnitOfVolume.CUBIC_METERS,
-            device_class=SensorDeviceClass.GAS,
-            state_class=SensorStateClass.TOTAL,
         )
 
         async_add_external_statistics(self.hass, cost_metadata, cost_statistics)

--- a/custom_components/gazdebordeaux/manifest.json
+++ b/custom_components/gazdebordeaux/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/chriscamicas/gazdebordeaux-ha/issues",
   "requirements": ["pytz"],
-  "version": "1.1.10"
+  "version": "1.1.11"
 }

--- a/custom_components/gazdebordeaux/sensor.py
+++ b/custom_components/gazdebordeaux/sensor.py
@@ -22,16 +22,14 @@ from .coordinator import GdbCoordinator
 from .gazdebordeaux import TotalUsageRead
 
 
-@dataclass
-class GdbEntityDescriptionMixin:
-    """Mixin values for required keys."""
+# SensorEntityDescription tightens device_class / state_class / etc. relative to
+# the base EntityDescription, so the synthesized `__replace__` here doesn't
+# match the grandparent's signature. Same pattern as HA core's `nrgkick` etc.
+@dataclass(frozen=True, kw_only=True)
+class GdbEntityDescription(SensorEntityDescription):  # type: ignore[override]
+    """Class describing Gaz de Bordeaux sensor entities."""
 
     value_fn: Callable[[TotalUsageRead], str | float]
-
-
-@dataclass
-class GdbEntityDescription(SensorEntityDescription, GdbEntityDescriptionMixin):
-    """Class describing Gaz de Bordeaux sensors entities."""
 
 
 # suggested_display_precision=0 for all sensors since


### PR DESCRIPTION
## Summary
Phase 5b, **stacked on top of #35**. Brings the integration up to current HA APIs and clears the remaining mypy drift errors. **One user-visible behavior change**: the cost statistic now correctly identifies as monetary in the Energy Dashboard.

### `coordinator.py`
- `StatisticMetaData` no longer accepts `device_class` / `state_class` (HA core moved them out — modern HA infers from `unit_class` + `unit_of_measurement`). Dropped those keys from all three metadata blocks.
- **Set `unit_class="monetary"` on the cost metadata** — the file already had this exact line commented out at the original `unit_class=None` site, clear intent never followed through. Energy Dashboard will now treat the cost series as a currency.
- Removed `has_mean=False`; redundant with `mean_type=StatisticMeanType.NONE` and scheduled for removal in HA 2026.4.

### `sensor.py`
- `EntityDescription` became frozen via the `FrozenOrThawed` metaclass, which broke the `@dataclass`-mixin shape (`Mixin` + `Description` subclass: "Cannot inherit non-frozen dataclass from a frozen one"). Collapsed the two classes into a single `@dataclass(frozen=True, kw_only=True) GdbEntityDescription(SensorEntityDescription)` — same pattern as HA core's `nrgkick` and similar integrations.
- Type-ignored an inherited `[override]` mismatch on `__replace__` (`SensorEntityDescription` tightens types vs. base `EntityDescription`; same noise exists in HA core).

## Verification
```
$ mypy custom_components/gazdebordeaux  # was 6 errors, now 0
Success: no issues found in 9 source files
$ pytest tests/                         # 13 passed
$ ruff check .                          # All checks passed!
```

## Merge order
Targets `chore/mypy-prep-types-and-redef` (#35); auto-retargets to `main` as upstream PRs land.

Phase 5c (one-line addition of `mypy custom_components/gazdebordeaux` to the lint job in `tests.yml`) can land immediately after this.