### PR TITLE
chore: bring tooling/QA stack to main (phases 2–5b, v1.1.11)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+name: Bug report
+description: Report a problem with the integration
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill in as much
+        of the form as you can — vague reports are hard to action.
+
+  - type: input
+    id: integration_version
+    attributes:
+      label: Integration version
+      description: From the manifest, or what HACS shows.
+      placeholder: e.g. 1.1.10
+    validations:
+      required: true
+
+  - type: input
+    id: ha_version
+    attributes:
+      label: Home Assistant version
+      placeholder: e.g. 2026.4.1
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the problem and what you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: |
+        Enable debug logging for this integration first:
+
+        ```yaml
+        logger:
+          logs:
+            custom_components.gazdebordeaux: debug
+        ```
+
+        Then paste the lines around the error. Redact your token, email, and
+        house UUIDs before submitting.
+      render: shell
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Screenshots, account specifics (multiple contracts, recent password change, etc.) — anything that might help.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Suggest an enhancement
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: A clear description of the user-facing pain point. "I can't see X", "I have to do Y manually every month", etc.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How you'd like the integration to behave.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you've considered
+      description: Other integrations, custom templates, automations — anything that already gets you partway there.
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Mockups, references to the Gaz de Bordeaux web/app behavior, etc.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,50 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint and format check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements_test.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_test.txt
+
+      - name: ruff check
+        run: ruff check .
+
+      - name: ruff format check
+        run: ruff format --check .
+
+  tests:
+    name: Pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements_test.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_test.txt
+
+      - name: Run pytest
+        run: pytest -v --cov=custom_components/gazdebordeaux --cov-report=term-missing

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements_test.txt
+          # Runtime deps live in manifest.json (HA convention); install them too.
+          pip install $(python -c "import json; print(' '.join(json.load(open('custom_components/gazdebordeaux/manifest.json'))['requirements']))")
 
       - name: Run pytest
         run: pytest -v --cov=custom_components/gazdebordeaux --cov-report=term-missing

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.7.4
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-added-large-files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.11] - 2026-04-28
+- Tag the cost statistic with `unit_class="monetary"` so the energy dashboard recognizes it as a currency series (was `None` before)
+- Drop deprecated `device_class` / `state_class` / `has_mean` keys from external statistic metadata; they're no longer accepted by the recorder's `StatisticMetaData` TypedDict in modern Home Assistant
+- Refactor `GdbEntityDescription` to the modern frozen+kw_only single-dataclass pattern (the old mixin shape doesn't compose with the now-frozen `EntityDescription`)
+
 ## [1.1.10] - 2026-04-25
 - Pick the first gas-contract house automatically when the account has multiple contracts and no `selectedHouse` (e.g. gas + electricity customers)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing
+
+Thanks for taking the time to contribute! This is a small custom integration for Home Assistant; the goal is to keep the loop fast and the surface area small.
+
+## Setup
+
+```bash
+# Python 3.13+ required (matches the HA version we test against)
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements_test.txt
+
+# Optional but recommended: enable git hooks so lint/format runs on commit
+pre-commit install
+```
+
+If your venv pre-dates a HA bump, refresh it:
+
+```bash
+pip install -r requirements_test.txt --upgrade
+```
+
+`pytest-homeassistant-custom-component` pulls a matched Home Assistant version, so you don't need to install HA separately.
+
+## Run the test suite
+
+```bash
+pytest                     # full suite
+pytest tests/              # phase-2 client tests only (fast, no HA)
+pytest tests/integration/  # HA-fixture-dependent tests (config flow, sensors)
+pytest --cov=custom_components/gazdebordeaux  # with coverage
+```
+
+CI runs the same lint and pytest commands on every push and PR (`.github/workflows/tests.yml`).
+
+## Lint and format
+
+We use [ruff](https://docs.astral.sh/ruff/) for both lint and format. Config lives in `pyproject.toml`.
+
+```bash
+ruff check .              # lint
+ruff check . --fix        # auto-fix what's safe
+ruff format .             # format
+ruff format --check .     # CI-style check, no changes
+```
+
+`pre-commit install` wires both into the commit hook so this happens automatically.
+
+## Manual smoke testing in Home Assistant
+
+A standalone script is included for hitting the upstream API without needing a running HA:
+
+```bash
+GDB_USERNAME=you@example.com GDB_PASSWORD='...' python test_login.py
+```
+
+It enables DEBUG logging so request URLs, response status, content-type, and bodies show up — useful when the upstream API changes shape.
+
+## Releasing
+
+1. Bump `custom_components/gazdebordeaux/manifest.json` `version`.
+2. Add a section to `CHANGELOG.md` (Keep a Changelog format).
+3. Open a PR, get CI green, merge.
+4. After merge, tag the commit: `git tag -a v1.1.X -m "..." && git push origin v1.1.X`. HACS picks up the release from the tag.
+
+If a version is sitting on an open PR and you make further changes before merging, fold them into the same version's changelog rather than bumping again — only bump after the previous version actually shipped to `main`.
+
+## Project notes
+
+`CLAUDE.md` at the repo root has a longer write-up of API quirks, payload shapes, and historical pitfalls (multi-house accounts, the WAF browser-headers requirement, the voluptuous `Optional(default=...)` trap). Worth a read before touching `gazdebordeaux.py` or the config flow.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Home Assistant Gaz De Bordeaux integration
 
+[![Tests](https://github.com/chriscamicas/gazdebordeaux-ha/actions/workflows/tests.yml/badge.svg)](https://github.com/chriscamicas/gazdebordeaux-ha/actions/workflows/tests.yml)
+[![hassfest](https://github.com/chriscamicas/gazdebordeaux-ha/actions/workflows/hassfest-action.yml/badge.svg)](https://github.com/chriscamicas/gazdebordeaux-ha/actions/workflows/hassfest-action.yml)
+[![HACS validation](https://github.com/chriscamicas/gazdebordeaux-ha/actions/workflows/hacs-action.yml/badge.svg)](https://github.com/chriscamicas/gazdebordeaux-ha/actions/workflows/hacs-action.yml)
+
 ## Installation
 ### Method 1 : HACS (recommended)
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,12 @@
+"""Project-root conftest.
+
+`pytest_plugins` must live at the rootdir conftest (pytest deprecation),
+so we load `pytest_homeassistant_custom_component` here. The plugin's
+fixtures are opt-in (e.g. `hass`, `recorder_mock`), so tests that don't
+request them aren't slowed down materially beyond the plugin's import
+cost.
+"""
+
+from __future__ import annotations
+
+pytest_plugins = ["pytest_homeassistant_custom_component"]

--- a/custom_components/gazdebordeaux/coordinator.py
+++ b/custom_components/gazdebordeaux/coordinator.py
@@ -16,10 +16,6 @@ from homeassistant.components.recorder.statistics import (
     statistics_during_period,
 )
 from homeassistant.components.recorder.util import get_instance
-from homeassistant.components.sensor import (
-    SensorDeviceClass,
-    SensorStateClass,
-)
 from homeassistant.const import (
     CONF_PASSWORD,
     CONF_USERNAME,
@@ -205,20 +201,15 @@ class GdbCoordinator(DataUpdateCoordinator[TotalUsageRead]):
         name_prefix = " ".join(("Gaz de Bordeaux",))
 
         cost_metadata = StatisticMetaData(
-            has_mean=False,
             mean_type=StatisticMeanType.NONE,
-            # unit_class="monetary",
-            unit_class=None,
+            unit_class="monetary",
             has_sum=True,
             name=f"{name_prefix} cost",
             source=DOMAIN,
             statistic_id=cost_statistic_id,
             unit_of_measurement=CURRENCY_EURO,
-            device_class=SensorDeviceClass.MONETARY,
-            state_class=SensorStateClass.TOTAL,
         )
         consumption_metadata = StatisticMetaData(
-            has_mean=False,
             mean_type=StatisticMeanType.NONE,
             unit_class="energy",
             has_sum=True,
@@ -226,11 +217,8 @@ class GdbCoordinator(DataUpdateCoordinator[TotalUsageRead]):
             source=DOMAIN,
             statistic_id=consumption_statistic_id,
             unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-            device_class=SensorDeviceClass.ENERGY,
-            state_class=SensorStateClass.TOTAL,
         )
         volume_metadata = StatisticMetaData(
-            has_mean=False,
             mean_type=StatisticMeanType.NONE,
             unit_class="volume",
             has_sum=True,
@@ -238,8 +226,6 @@ class GdbCoordinator(DataUpdateCoordinator[TotalUsageRead]):
             source=DOMAIN,
             statistic_id=volume_statistic_id,
             unit_of_measurement=UnitOfVolume.CUBIC_METERS,
-            device_class=SensorDeviceClass.GAS,
-            state_class=SensorStateClass.TOTAL,
         )
 
         async_add_external_statistics(self.hass, cost_metadata, cost_statistics)

--- a/custom_components/gazdebordeaux/coordinator.py
+++ b/custom_components/gazdebordeaux/coordinator.py
@@ -77,10 +77,6 @@ class GdbCoordinator(DataUpdateCoordinator[TotalUsageRead]):
                 _LOGGER.debug("Asked to reset all statistics...")
                 entries = self.hass.config_entries.async_entries(DOMAIN)
 
-                house: Any = None
-                if HOUSE in entry_data:
-                    house = entry_data[HOUSE]
-
                 _LOGGER.debug("Updating config...")
                 self.hass.config_entries.async_update_entry(
                     entries[0],

--- a/custom_components/gazdebordeaux/manifest.json
+++ b/custom_components/gazdebordeaux/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/chriscamicas/gazdebordeaux-ha/issues",
   "requirements": ["pytz"],
-  "version": "1.1.10"
+  "version": "1.1.11"
 }

--- a/custom_components/gazdebordeaux/sensor.py
+++ b/custom_components/gazdebordeaux/sensor.py
@@ -22,16 +22,14 @@ from .coordinator import GdbCoordinator
 from .gazdebordeaux import TotalUsageRead
 
 
-@dataclass
-class GdbEntityDescriptionMixin:
-    """Mixin values for required keys."""
+# SensorEntityDescription tightens device_class / state_class / etc. relative to
+# the base EntityDescription, so the synthesized `__replace__` here doesn't
+# match the grandparent's signature. Same pattern as HA core's `nrgkick` etc.
+@dataclass(frozen=True, kw_only=True)
+class GdbEntityDescription(SensorEntityDescription):  # type: ignore[override]
+    """Class describing Gaz de Bordeaux sensor entities."""
 
     value_fn: Callable[[TotalUsageRead], str | float]
-
-
-@dataclass
-class GdbEntityDescription(SensorEntityDescription, GdbEntityDescriptionMixin):
-    """Class describing Gaz de Bordeaux sensors entities."""
 
 
 # suggested_display_precision=0 for all sensors since

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ files = ["custom_components/gazdebordeaux"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
 log_cli = true
 log_cli_level = "INFO"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,3 +5,4 @@ pytest-homeassistant-custom-component>=0.13.300
 aioresponses==0.7.*
 ruff==0.7.*
 mypy==1.13.*
+types-pytz

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,5 +2,6 @@ pytest==8.*
 pytest-asyncio==0.24.*
 pytest-cov==5.*
 pytest-homeassistant-custom-component==0.13.*
+aioresponses==0.7.*
 ruff==0.7.*
 mypy==1.13.*

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,9 @@
 pytest==8.*
 pytest-asyncio==0.24.*
 pytest-cov==5.*
-pytest-homeassistant-custom-component==0.13.*
 aioresponses==0.7.*
 ruff==0.7.*
 mypy==1.13.*
+# pytest-homeassistant-custom-component will be added in the phase that
+# introduces HA-fixture-dependent tests; pinning it here would force pytest
+# to load the plugin (and Home Assistant itself) on every run.

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,9 +1,7 @@
-pytest==8.*
-pytest-asyncio==0.24.*
-pytest-cov==5.*
+# pytest-homeassistant-custom-component pulls pytest, pytest-asyncio, and
+# pytest-cov, all version-matched to the Home Assistant release it targets.
+# Pinning them separately tends to fight that resolution.
+pytest-homeassistant-custom-component>=0.13.300
 aioresponses==0.7.*
 ruff==0.7.*
 mypy==1.13.*
-# pytest-homeassistant-custom-component will be added in the phase that
-# introduces HA-fixture-dependent tests; pinning it here would force pytest
-# to load the plugin (and Home Assistant itself) on every run.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Shared pytest fixtures for the gazdebordeaux integration tests.
+
+Phase 3 will add `pytest_plugins = ["pytest_homeassistant_custom_component"]`
+once HA-fixture-dependent tests are added (config flow, sensor entities).
+For now the test suite is pure-Python so we keep this conftest minimal to
+avoid pulling Home Assistant into the test environment.
+"""
+
+from __future__ import annotations

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 """Shared pytest fixtures for the gazdebordeaux integration tests.
 
-Phase 3 will add `pytest_plugins = ["pytest_homeassistant_custom_component"]`
-once HA-fixture-dependent tests are added (config flow, sensor entities).
-For now the test suite is pure-Python so we keep this conftest minimal to
-avoid pulling Home Assistant into the test environment.
+The pure-Python API client tests at this level don't need Home Assistant.
+Tests that *do* need HA fixtures live under `tests/integration/` and pull
+in `pytest_homeassistant_custom_component` via that subdirectory's
+conftest.
 """
 
 from __future__ import annotations

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,18 @@
+"""Pytest fixtures for the HA-fixture-dependent integration tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _ha_test_setup(recorder_mock, enable_custom_integrations):
+    """Order-sensitive setup for every integration test.
+
+    `recorder_mock` MUST be set up before `hass` (the HA test plugin
+    asserts that), and `enable_custom_integrations` is needed for HA's
+    loader to discover this repo. Combining them in a single autouse
+    fixture guarantees the order regardless of how individual tests
+    declare their parameters.
+    """
+    yield

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -1,0 +1,58 @@
+"""Tests for the gazdebordeaux config flow."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.gazdebordeaux.const import DOMAIN
+
+USERNAME = "user@example.com"
+PASSWORD = "secret"
+
+
+async def test_form_happy_path(hass: HomeAssistant) -> None:
+    """A valid login should create a config entry titled with the email."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    with patch(
+        "custom_components.gazdebordeaux.config_flow.Gazdebordeaux.async_login",
+        return_value=None,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == f"({USERNAME})"
+    assert result["data"] == {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+
+
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
+    """A failing login should re-display the form with an invalid_auth error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "custom_components.gazdebordeaux.config_flow.Gazdebordeaux.async_login",
+        side_effect=Exception("bad credentials"),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: USERNAME, CONF_PASSWORD: "wrong"},
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}

--- a/tests/integration/test_sensor.py
+++ b/tests/integration/test_sensor.py
@@ -1,0 +1,52 @@
+"""Tests for the gazdebordeaux sensor platform."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.gazdebordeaux.const import DOMAIN
+from custom_components.gazdebordeaux.gazdebordeaux import TotalUsageRead
+
+USERNAME = "user@example.com"
+PASSWORD = "secret"
+
+
+async def test_sensors_expose_total_usage_values(hass: HomeAssistant) -> None:
+    """The three gas sensors should reflect the TotalUsageRead the API returns."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+    )
+    entry.add_to_hass(hass)
+
+    canned = TotalUsageRead(amountOfEnergy=1234.0, volumeOfEnergy=110.5, price=180.42)
+
+    with (
+        patch(
+            "custom_components.gazdebordeaux.coordinator.Gazdebordeaux.async_login",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "custom_components.gazdebordeaux.coordinator.Gazdebordeaux.async_get_total_usage",
+            new=AsyncMock(return_value=canned),
+        ),
+        # _insert_statistics also fetches daily history; make it a no-op for this test.
+        patch(
+            "custom_components.gazdebordeaux.coordinator.GdbCoordinator._insert_statistics",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state_volume = hass.states.get("sensor.current_bill_gas_usage_to_date")
+    state_energy = hass.states.get("sensor.current_energy_usage_to_date")
+    state_cost = hass.states.get("sensor.current_bill_gas_cost_to_date")
+
+    assert state_volume is not None and float(state_volume.state) == 110.5
+    assert state_energy is not None and float(state_energy.state) == 1234.0
+    assert state_cost is not None and float(state_cost.state) == 180.42

--- a/tests/test_gazdebordeaux.py
+++ b/tests/test_gazdebordeaux.py
@@ -1,0 +1,153 @@
+"""Pure-Python tests for the Gazdebordeaux API client.
+
+These exercise the HTTP contract by mocking aiohttp via aioresponses; no
+Home Assistant fixtures are needed. We import `gazdebordeaux` as a
+top-level module to avoid pulling the package's `__init__.py`, which
+imports Home Assistant.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from aiohttp import ClientSession
+from aioresponses import aioresponses
+
+sys.path.insert(
+    0, str(Path(__file__).resolve().parent.parent / "custom_components" / "gazdebordeaux")
+)
+from gazdebordeaux import (
+    DATA_URL,
+    LOGIN_URL,
+    ME_URL,
+    Gazdebordeaux,
+)
+
+USERNAME = "user@example.com"
+PASSWORD = "secret"
+TOKEN = "fake-jwt-token"
+HOUSE_PATH = "/api/houses/abc"
+DATA_HOST = "https://life.gazdebordeaux.fr"
+
+
+@pytest.fixture
+def http_mock():
+    with aioresponses() as m:
+        yield m
+
+
+@pytest.fixture
+async def session():
+    async with ClientSession() as s:
+        yield s
+
+
+# ---------- async_login -----------------------------------------------------
+
+
+async def test_login_stores_token(http_mock, session):
+    http_mock.post(LOGIN_URL, payload={"token": TOKEN})
+
+    api = Gazdebordeaux(session, USERNAME, PASSWORD)
+    await api.async_login()
+
+    assert api._token == TOKEN
+
+
+async def test_login_html_response_raises(http_mock, session):
+    http_mock.post(
+        LOGIN_URL,
+        status=403,
+        body="<html>403 Forbidden</html>",
+        headers={"Content-Type": "text/html"},
+    )
+
+    api = Gazdebordeaux(session, USERNAME, PASSWORD)
+    with pytest.raises(Exception, match="Login response was not JSON"):
+        await api.async_login()
+
+
+async def test_login_null_token_raises(http_mock, session):
+    http_mock.post(LOGIN_URL, payload={"token": None})
+
+    api = Gazdebordeaux(session, USERNAME, PASSWORD)
+    with pytest.raises(Exception, match="invalid auth"):
+        await api.async_login()
+
+
+# ---------- loadHouse: selectedHouse path ----------------------------------
+
+
+async def test_loadhouse_uses_selected_house(http_mock, session):
+    http_mock.get(ME_URL, payload={"selectedHouse": HOUSE_PATH, "houses": [HOUSE_PATH]})
+
+    api = Gazdebordeaux(session, USERNAME, PASSWORD, token=TOKEN)
+    await api.loadHouse()
+
+    assert api._selectedHouse == HOUSE_PATH
+
+
+# ---------- loadHouse: multi-house iteration -------------------------------
+
+
+async def test_loadhouse_picks_gas_house(http_mock, session):
+    elec = "/api/houses/elec-uuid"
+    gas = "/api/houses/gas-uuid"
+
+    http_mock.get(ME_URL, payload={"selectedHouse": None, "houses": [elec, gas]})
+    http_mock.get(f"{DATA_HOST}{elec}", payload={"contractType": {"category": "electricity"}})
+    http_mock.get(f"{DATA_HOST}{gas}", payload={"contractType": {"category": "gas"}})
+
+    api = Gazdebordeaux(session, USERNAME, PASSWORD, token=TOKEN)
+    await api.loadHouse()
+
+    assert api._selectedHouse == gas
+
+
+async def test_loadhouse_no_gas_raises(http_mock, session):
+    elec1 = "/api/houses/elec1"
+    elec2 = "/api/houses/elec2"
+
+    http_mock.get(ME_URL, payload={"selectedHouse": None, "houses": [elec1, elec2]})
+    http_mock.get(f"{DATA_HOST}{elec1}", payload={"contractType": {"category": "electricity"}})
+    http_mock.get(f"{DATA_HOST}{elec2}", payload={"contractType": {"category": "electricity"}})
+
+    api = Gazdebordeaux(session, USERNAME, PASSWORD, token=TOKEN)
+    with pytest.raises(Exception, match="No gas contract found"):
+        await api.loadHouse()
+
+
+async def test_loadhouse_empty_houses_raises(http_mock, session):
+    http_mock.get(ME_URL, payload={"selectedHouse": None, "houses": []})
+
+    api = Gazdebordeaux(session, USERNAME, PASSWORD, token=TOKEN)
+    with pytest.raises(Exception, match="No houses found"):
+        await api.loadHouse()
+
+
+# ---------- async_get_data: house path normalization -----------------------
+
+
+@pytest.mark.parametrize(
+    "house_in",
+    [
+        "/api/houses/abc",  # already prefixed
+        "/houses/abc",  # missing /api
+        "houses/abc",  # missing both leading slash and /api
+    ],
+)
+async def test_data_url_normalization(http_mock, session, house_in):
+    expected_url = DATA_URL.format("/api/houses/abc")
+    http_mock.get(
+        f"{expected_url}?scale=year",
+        payload={"total": {"kwh": 100, "volumeOfEnergy": 10, "price": 50}},
+    )
+
+    api = Gazdebordeaux(session, USERNAME, PASSWORD, token=TOKEN, house=house_in)
+    result = await api.async_get_total_usage()
+
+    assert result.amountOfEnergy == 100
+    assert result.volumeOfEnergy == 10
+    assert result.price == 50


### PR DESCRIPTION
## Summary
Consolidates the five stacked PRs that had each squash-merged into their parent branch rather than `main`:

- **#32** phase 2 — tests workflow + API client tests
- **#33** phase 3 — config flow & sensor tests via `pytest-homeassistant-custom-component`
- **#34** phase 4 — pre-commit, dependabot, issue templates, CONTRIBUTING, README badges
- **#35** phase 5a — `types-pytz` + dead variable redef cleanup
- **#36** phase 5b — modern `StatisticMetaData` / `EntityDescription` shape, v1.1.11

Phase 1 (#31) already landed on `main`, so this PR's diff is just the additive phase 2–5b content (no phase 1 duplication).

**Recommended merge strategy: Rebase and merge** — keeps each phase as a distinct commit on `main` so the per-phase context survives in `git log`.