### PR TITLE
ci: enable mypy in the lint job (phase 5c)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,9 @@ jobs:
       - name: ruff format check
         run: ruff format --check .
 
+      - name: mypy
+        run: mypy custom_components/gazdebordeaux
+
   tests:
     name: Pytest
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Phase 5c — wires `mypy custom_components/gazdebordeaux` into the existing lint job in `tests.yml`. Now that phase 5b cleared the last typing drift, this keeps the codebase clean as it evolves.

The lint job already installs `requirements_test.txt`, which pulls Home Assistant transitively via `pytest-homeassistant-custom-component`, so mypy can resolve the `homeassistant.*` imports without extra setup.

## Verification
```
$ mypy custom_components/gazdebordeaux
Success: no issues found in 9 source files
```